### PR TITLE
Fix: unset lang to use `ls` default outpur order

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -7,7 +7,7 @@
     sed '/^const data = \[$/q' index.html
 
     FIRST=1
-    ls -1 */results/*.json | while read file
+    LANG="" ls -1 */results/*.json | while read file
     do
         [[ $file =~ ^(hardware|versions)/ ]] && continue;
 


### PR DESCRIPTION
After submitting my pull request, I observed that a GitHub bot appended an additional commit to update the `index.html` file. However, I had executed the `generate-result.sh script`. Consequently, I investigated this issue and discovered that the order of the content output by the `ls` command is influenced by different languages.

`LANG=en_US.UTF-8`
```bash
LANG=en_US.UTF-8 ls -1 */results/*.json | tail
versions/results/23.1.7.30.json
versions/results/23.2.7.32.json
versions/results/23.3.8.21.json
versions/results/23.4.6.25.json
versions/results/23.5.4.25.json
versions/results/23.6.2.18.json
versions/results/23.7.5.30_old.json
versions/results/23.7.6.111.json
versions/results/23.8.7.24.json
versions/results/23.9.5.29.json
```

`LANG=""`
```bash
LANG="" ls -1 */results/*.json | tail
versions/results/23.10.4.25.json
versions/results/23.2.7.32.json
versions/results/23.3.8.21.json
versions/results/23.4.6.25.json
versions/results/23.5.4.25.json
versions/results/23.6.2.18.json
versions/results/23.7.5.30_old.json
versions/results/23.7.6.111.json
versions/results/23.8.7.24.json
versions/results/23.9.5.29.json
```