### PR TITLE
Fix the log path when running the tail command

### DIFF
--- a/hardware/hardware.sh
+++ b/hardware/hardware.sh
@@ -30,7 +30,7 @@ trap finish EXIT
 
 echo "Waiting for clickhouse-server to start"
 
-tail -n+0 -f /clickhouse-benchmark/server.log | grep --max-count 1 'Ready for connections'
+tail -n+0 -f ./server.log | grep --max-count 1 'Ready for connections'
 
 for i in {1..300}; do
     sleep 1


### PR DESCRIPTION
# Changed log

- Fix the `tail` command with correct log path in the `hardware.sh` file.
  - We've used the `pushd clickhouse-benchmark ` command to change the directory before running the `tail` command.
  - The log path should be `./server.log`.

Otherwise it will be failed when running the `hardware.sh` script:

```sh
$ ./hardware.sh
......
Waiting for clickhouse-server to start
tail: cannot open '/clickhouse-benchmark/server.log' for reading: No such file or directory
tail: no files remaining
```