### PR TITLE
Use the fast channel in ClickHouse Cloud

### DIFF
--- a/clickhouse-cloud/cloud-api.sh
+++ b/clickhouse-cloud/cloud-api.sh
@@ -25,6 +25,7 @@ curl -X POST -H 'Content-Type: application/json' -d '
 {
     "name": "ClickBench-'${PROVIDER}'-'${REGION}'-'${TIER}'-'${MEMORY}'-'$$'",
     "tier": "'$TIER'",
+    "releaseChannel": "fast",
     "provider": "'$PROVIDER'",
     "region": "'$REGION'",
     '$([ $TIER == production ] && echo -n "\"minTotalMemoryGb\":${MEMORY},\"maxTotalMemoryGb\":${MEMORY},")'


### PR DESCRIPTION
The fast channel is the channel where releases appear earlier, but the customers can only create lower-severity support tickets.