### PR TITLE
chore: check env variable before running clickhouse cloud workflow

### DIFF
--- a/.github/workflows/clickhouse-cloud.yml
+++ b/.github/workflows/clickhouse-cloud.yml
@@ -19,7 +19,12 @@ jobs:
         export ORGANIZATION=${{ secrets.CLICKHOUSE_CLOUD_ORGANIZATION }}
         export KEY_ID=${{ secrets.CLICKHOUSE_CLOUD_KEY_ID }}
         export KEY_SECRET=${{ secrets.CLICKHOUSE_CLOUD_KEY_SECRET }}
-        
+
+        if [ -z "$ORGANIZATION" ] || [ -z "$KEY_ID" ] || [ -z "$KEY_SECRET" ]; then
+          echo "Required secrets are not set. Skipping workflow."
+          exit 0
+        fi
+
         cd clickhouse-cloud
         curl https://clickhouse.com/ | sh
         sudo ./clickhouse install -y


### PR DESCRIPTION
When I forked the repo, the clickhouse cloud github action runs everyday and [fails](https://github.com/pmcgleenon/ClickBench/actions/runs/12233494986/job/34120707806) after trying to execute the full action.  To fix it I added a basic check at the start for the clickhouse cloud credentials

