### PR TITLE
Include node count in instance name (proper version)

### DIFF
--- a/clickhouse-cloud/collect-results.sh
+++ b/clickhouse-cloud/collect-results.sh
@@ -15,7 +15,7 @@ do
 {
     "system": "ClickHouse Cloud ('$PROVIDER')",
     "date": "'$(date +%F)'",
-    "machine": "'$MEMORY'GiB",
+    "machine": "'$MEMORY'GiB, '$REPLICAS' replicas",
     "cluster_size": "'$REPLICAS'",
     "comment": "",
 


### PR DESCRIPTION
In #296, I missed that the result `.json` files are automatically regenerated by CI(e.g. [here](https://github.com/ClickHouse/ClickBench/commit/e3a28f09d93deb89e7ca2b40aa2113d4095f7121)). This time, adjust the script.