### PR TITLE
Refactor `postgresql/benchmark.sh` to Wrap COPY FREEZE in a Transaction Block

### DIFF
--- a/postgresql/benchmark.sh
+++ b/postgresql/benchmark.sh
@@ -10,7 +10,14 @@ chmod 777 ~ hits.tsv
 
 sudo -u postgres psql -t -c 'CREATE DATABASE test'
 sudo -u postgres psql test -t < create.sql
-sudo -u postgres psql test -t -c '\timing' -c "\\copy hits FROM 'hits.tsv' with freeze"
+
+# Load data: wrap TRUNCATE and \copy FREEZE in a single transaction
+sudo -u postgres psql test <<'EOF'
+BEGIN;
+TRUNCATE TABLE hits;
+\copy hits FROM 'hits.tsv' with freeze;
+COMMIT;
+EOF
 
 sudo -u postgres psql test -t -c 'VACUUM ANALYZE hits'
 

--- a/postgresql/benchmark.sh
+++ b/postgresql/benchmark.sh
@@ -12,6 +12,9 @@ sudo -u postgres psql -t -c 'CREATE DATABASE test'
 sudo -u postgres psql test -t < create.sql
 
 # Load data: wrap TRUNCATE and \copy FREEZE in a single transaction
+# If we dont' do this, Postgres will throw an error:
+#     "ERROR: cannot perform COPY FREEZE because the table was not created or truncated in the current subtransaction"
+# (i.e. Postgres requires that the table be either created or truncated in the current subtransaction)
 sudo -u postgres psql test <<'EOF'
 BEGIN;
 TRUNCATE TABLE hits;


### PR DESCRIPTION
## Overview
This PR fixes an issue in the PostgreSQL benchmark script where the use of the `COPY ... with freeze command` fails because PostgreSQL requires that the table be either created or truncated in the current subtransaction. 

Previously, the script executed the `\copy` command (with the freeze option) outside of any transaction block, resulting in the following error:
```shell
ERROR: cannot perform COPY FREEZE because the table was not created or truncated in the current subtransaction
```
## Changes

*   **Transaction Wrapping:**  
    The data load is now performed inside a transaction block. The script first truncates the `hits` table and then runs the `\copy` command with the `freeze` option—all within the same transaction. This guarantees that PostgreSQL accepts the `COPY FREEZE` operation.
  
Looking forward to your feedback and suggestions!

## Fix
This PR fixes this [issue](https://github.com/ClickHouse/ClickBench/issues/234#issuecomment-2499128995).

