### PR TITLE
Remove `--no-verbose` flag from wget

### DIFF
--- a/aurora-mysql/README.md
+++ b/aurora-mysql/README.md
@@ -37,7 +37,7 @@ mysql -h "${FQDN}" -u admin --password="${PASSWORD}" -e "CREATE DATABASE test"
 Load the data
 
 ```
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 mysql -h "${FQDN}" -u admin --password="${PASSWORD}" test < create.sql

--- a/aurora-postgresql/README.md
+++ b/aurora-postgresql/README.md
@@ -36,7 +36,7 @@ chmod 400 .pgpass
 Load the data
 
 ```
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 psql -U postgres -h "${FQDN}" -t -c 'CREATE DATABASE test'

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -19,7 +19,7 @@ source .bashrc
 
 Load the data:
 ```
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 time bq load --source_format CSV --allow_quoted_newlines=1 test.hits hits.csv

--- a/byconity/benchmark.sh
+++ b/byconity/benchmark.sh
@@ -12,7 +12,7 @@ function byconity()
 export -f byconity
 
 byconity --time -n < create.sql
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 pigz -fkd hits.tsv.gz
 byconity --database bench --query "INSERT INTO hits FORMAT TSV" < hits.tsv
 

--- a/bytehouse/NOTES.md
+++ b/bytehouse/NOTES.md
@@ -199,7 +199,7 @@ Trash.
 Will try CSV.
 
 ```
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 ```
 

--- a/bytehouse/README.md
+++ b/bytehouse/README.md
@@ -28,7 +28,7 @@ export warehouse='test'
 ```
 
 ```
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 ```
 

--- a/chdb-dataframe/benchmark.sh
+++ b/chdb-dataframe/benchmark.sh
@@ -8,7 +8,7 @@ pip install --break-system-packages pandas
 pip install --break-system-packages chdb==2.2.0b1
 
 # Download the data
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 
 # Run the queries
 

--- a/chdb-parquet/benchmark.sh
+++ b/chdb-parquet/benchmark.sh
@@ -8,7 +8,7 @@ pip install --break-system-packages psutil
 pip install --break-system-packages chdb==2.2.0b1
 
 # Load the data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 # Run the queries
 

--- a/chdb/benchmark.sh
+++ b/chdb/benchmark.sh
@@ -7,7 +7,7 @@ pip install --break-system-packages psutil
 pip install --break-system-packages chdb==2.2.0b1
 
 # Load the data
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 ./load.py
 

--- a/citus/benchmark.sh
+++ b/citus/benchmark.sh
@@ -6,7 +6,7 @@ sudo apt-get install -y postgresql-client
 
 sudo docker run -d --name citus -p 5432:5432 -e POSTGRES_PASSWORD=mypass citusdata/citus:11.0
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 echo "*:*:*:*:mypass" > .pgpass

--- a/clickhouse-parquet/benchmark.sh
+++ b/clickhouse-parquet/benchmark.sh
@@ -5,10 +5,10 @@
 curl https://clickhouse.com/ | sh
 
 # Use for ClickHouse (Parquet, single)
-# wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+# wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
 
 # Use for ClickHouse (Parquet, partitioned)
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 # Run the queries
 

--- a/clickhouse-parquet/cloud-init.sh
+++ b/clickhouse-parquet/cloud-init.sh
@@ -12,12 +12,12 @@ chmod +x *.sh
 
 curl https://clickhouse.com/ | sh
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --continue https://clickhouse-public-datasets.s3.amazonaws.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue https://clickhouse-public-datasets.s3.amazonaws.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 echo "Partitioned:" > log
 ./run.sh >> log
 
-wget --no-verbose --continue 'https://clickhouse-public-datasets.s3.amazonaws.com/hits_compatible/hits.parquet'
+wget --continue 'https://clickhouse-public-datasets.s3.amazonaws.com/hits_compatible/hits.parquet'
 
 sed -i 's/hits_\*\.parquet/hits.parquet/' create.sql
 

--- a/clickhouse/benchmark.sh
+++ b/clickhouse/benchmark.sh
@@ -35,7 +35,7 @@ fi
 
 clickhouse-client < create"$SUFFIX".sql
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 clickhouse-client --time --query "INSERT INTO hits FORMAT TSV" < hits.tsv

--- a/cratedb/benchmark.sh
+++ b/cratedb/benchmark.sh
@@ -34,7 +34,7 @@ do
   sleep 1
 done
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz' -O /tmp/hits.tsv.gz
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz' -O /tmp/hits.tsv.gz
 gzip -d /tmp/hits.tsv.gz
 chmod 444 /tmp/hits.tsv
 

--- a/databend/benchmark.sh
+++ b/databend/benchmark.sh
@@ -26,7 +26,7 @@ CONF
 # Docs: https://databend.rs/doc/use-cases/analyze-hits-dataset-with-databend
 curl 'http://default@localhost:8124/' --data-binary @create.sql
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 ## Aws gp2 write performance is not stable, we must load the data when disk's write around ~500MB/s (Don't know much about the rules of gp2)

--- a/datafusion/README.md
+++ b/datafusion/README.md
@@ -34,5 +34,5 @@ The benchmark should be completed in under an hour. On-demand pricing is $0.6 pe
 ## Generate full human readable results (for debugging)
 
 1. install datafusion-cli
-2. download the parquet ```wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/hits.parquet```
+2. download the parquet ```wget --continue https://datasets.clickhouse.com/hits_compatible/hits.parquet```
 3. execute it ```datafusion-cli -f create.sh queries.sh``` or ```bash run2.sh```

--- a/datafusion/benchmark.sh
+++ b/datafusion/benchmark.sh
@@ -21,11 +21,11 @@ cd ../..
 
 
 # Download benchmark target data, single file
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/hits.parquet
 
 # Download benchmark target data, partitioned
 mkdir -p partitioned
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --directory-prefix partitioned --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix partitioned --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 # Run benchmarks for single parquet and partitioned
 ./run.sh single

--- a/doris/benchmark.sh
+++ b/doris/benchmark.sh
@@ -15,7 +15,7 @@ fi
 file_name="$(basename ${url})"
 if [[ "$url" == "http"* ]]; then
     if [[ ! -f $file_name ]]; then
-        wget --no-verbose --continue ${url}
+        wget --continue ${url}
     else
         echo "$file_name already exists, no need to download."
     fi
@@ -88,7 +88,7 @@ mysql -h 127.0.0.1 -P9030 -uroot hits <"$ROOT"/create.sql
 
 # Download data
 if [[ ! -f hits.tsv.gz ]] && [[ ! -f hits.tsv ]]; then
-    wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+    wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
     gzip -d hits.tsv.gz
 fi
 

--- a/drill/benchmark.sh
+++ b/drill/benchmark.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get install -y docker.io
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
 
 ./run.sh 2>&1 | tee log.txt
 

--- a/druid/benchmark.sh
+++ b/druid/benchmark.sh
@@ -26,7 +26,7 @@ echo "druid.query.groupBy.maxMergingDictionarySize=5000000000" >> apache-druid-$
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 ./apache-druid-${VERSION}/bin/post-index-task --file ingest.json --url http://localhost:8081

--- a/duckdb-dataframe/benchmark.sh
+++ b/duckdb-dataframe/benchmark.sh
@@ -7,7 +7,7 @@ sudo apt-get install -y python3-pip
 pip install --break-system-packages pandas duckdb==1.1.3
 
 # Download the data
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 
 # Run the queries
 

--- a/duckdb-memory/benchmark.sh
+++ b/duckdb-memory/benchmark.sh
@@ -8,7 +8,7 @@ pip install --break-system-packages duckdb==1.1.3 psutil
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 # Run the queries

--- a/duckdb-parquet/benchmark.sh
+++ b/duckdb-parquet/benchmark.sh
@@ -14,7 +14,7 @@ export PATH="$PATH:`pwd`/build/release/"
 cd ..
 
 # Load the data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 time duckdb hits.db -f create.sql
 

--- a/duckdb/benchmark.sh
+++ b/duckdb/benchmark.sh
@@ -14,7 +14,7 @@ export PATH="$PATH:`pwd`/build/release/"
 cd ..
 
 # Load the data
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 time duckdb hits.db -f create.sql -c "COPY hits FROM 'hits.tsv' (QUOTE '')"

--- a/heavyai/benchmark.sh
+++ b/heavyai/benchmark.sh
@@ -27,7 +27,7 @@ sudo systemctl enable heavydb
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 chmod 777 ~ hits.csv
 

--- a/hydra/benchmark.sh
+++ b/hydra/benchmark.sh
@@ -7,7 +7,7 @@ sudo ./install.sh
 
 # download hits.tsv if we dont already have it
 if [ ! -e hits.tsv ]; then
-    wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+    wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
     gzip -d hits.tsv.gz
 fi
 

--- a/hyper-parquet/benchmark.sh
+++ b/hyper-parquet/benchmark.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 sudo apt-get install -y python3-pip
 pip install --break-system-packages tableauhyperapi
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 ./run.sh | tee log.txt
 

--- a/hyper/benchmark.sh
+++ b/hyper/benchmark.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 sudo apt-get install -y python3-pip
 pip install --break-system-packages tableauhyperapi
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 ./load.py

--- a/infobright/benchmark.sh
+++ b/infobright/benchmark.sh
@@ -13,7 +13,7 @@ sudo docker run -it --rm --network host mysql:5 mysql --host 127.0.0.1 --port 50
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 # ERROR 2 (HY000) at line 1: Wrong data or column definition. Row: 93557187, field: 100.

--- a/kinetica/benchmark.sh
+++ b/kinetica/benchmark.sh
@@ -13,7 +13,7 @@ export KI_PWD=admin
 CLI="./kisql --host localhost --user admin"
 
 # download the ds
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 # prepare the ds for ingestion; bigger files cause out of memory error

--- a/locustdb/benchmark.sh
+++ b/locustdb/benchmark.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y g++ capnproto libclang-14-dev
 
 cargo build --features "enable_rocksdb" --features "enable_lz4" --release
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 target/release/repl --load hits.csv --db-path db

--- a/mariadb-columnstore/benchmark.sh
+++ b/mariadb-columnstore/benchmark.sh
@@ -16,7 +16,7 @@ mysql --password="${PASSWORD}" --host 127.0.0.1 test < create.sql
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 time mysql --password="${PASSWORD}" --host 127.0.0.1 test -e "

--- a/mariadb/benchmark.sh
+++ b/mariadb/benchmark.sh
@@ -14,7 +14,7 @@ sudo service mariadb restart
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 sudo mariadb -e "CREATE DATABASE test"

--- a/monetdb/benchmark.sh
+++ b/monetdb/benchmark.sh
@@ -22,7 +22,7 @@ sudo apt-get install -y expect
 
 ./query.expect "$(cat create.sql)"
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 777 ~ hits.tsv
 

--- a/mongodb/benchmark.sh
+++ b/mongodb/benchmark.sh
@@ -55,7 +55,7 @@ time mongosh --quiet --eval 'db.hits.createIndex({"ClientIP": 1, "WatchID": 1, "
 
 #################################
 # Load data and import
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 # Use mongo import to load data into mongo. By default numInsertionWorkers is 1 so change to half of VM where it would be run

--- a/mysql-myisam/benchmark.sh
+++ b/mysql-myisam/benchmark.sh
@@ -9,7 +9,7 @@ sudo service mysql restart
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 sudo mysql -e "CREATE DATABASE test"

--- a/mysql/benchmark.sh
+++ b/mysql/benchmark.sh
@@ -9,7 +9,7 @@ sudo service mysql restart
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 sudo mysql -e "CREATE DATABASE test"

--- a/octosql/benchmark.sh
+++ b/octosql/benchmark.sh
@@ -3,7 +3,7 @@
 wget https://github.com/cube2222/octosql/releases/download/v0.13.0/octosql_0.13.0_linux_amd64.tar.gz
 tar xf octosql_0.13.0_linux_amd64.tar.gz
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
 
 ./run.sh 2>&1 | tee log.txt
 

--- a/opteryx/benchmark.sh
+++ b/opteryx/benchmark.sh
@@ -19,7 +19,7 @@ source ~/opteryx_venv/bin/activate
 
 # Download benchmark target data, partitioned
 mkdir -p hits
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --directory-prefix hits --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix hits --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 
 # Run a simple query to check the installation
 ~/opteryx_venv/bin/python -m opteryx "SELECT version()" 2>&1

--- a/oxla/benchmark.sh
+++ b/oxla/benchmark.sh
@@ -9,7 +9,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential
 
 # download dataset
 echo "Download dataset."
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 echo "Unpack dataset."
 gzip -d hits.csv.gz
 mkdir data

--- a/pandas/benchmark.sh
+++ b/pandas/benchmark.sh
@@ -7,7 +7,7 @@ sudo apt-get install -y python3-pip
 pip install --break-system-packages pandas
 
 # Download the data
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 
 # Run the queries
 

--- a/paradedb/benchmark.sh
+++ b/paradedb/benchmark.sh
@@ -64,7 +64,7 @@ echo ""
 echo "Downloading ClickBench dataset ($FLAG_WORKLOAD)..."
 if [ $FLAG_WORKLOAD == "single" ]; then
   if [ ! -e /tmp/hits.parquet ]; then
-    wget --no-verbose --continue -O /tmp/hits.parquet https://datasets.clickhouse.com/hits_compatible/hits.parquet
+    wget --continue -O /tmp/hits.parquet https://datasets.clickhouse.com/hits_compatible/hits.parquet
   fi
   if ! sudo docker exec paradedb sh -c '[ -f /tmp/hits.parquet ]'; then
     sudo docker cp /tmp/hits.parquet paradedb:/tmp/hits.parquet
@@ -72,7 +72,7 @@ if [ $FLAG_WORKLOAD == "single" ]; then
 elif [ $FLAG_WORKLOAD == "partitioned" ]; then
   if [ ! -e /tmp/partitioned/ ]; then
     mkdir -p /tmp/partitioned
-    seq 0 99 | xargs -P100 -I{} bash -c 'wget --no-verbose --directory-prefix /tmp/partitioned --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+    seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix /tmp/partitioned --continue https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
   fi
   if ! sudo docker exec paradedb sh -c '[ -f /tmp/partitioned ]'; then
     sudo docker cp /tmp/partitioned paradedb:tmp

--- a/pg_duckdb/benchmark.sh
+++ b/pg_duckdb/benchmark.sh
@@ -6,7 +6,7 @@ set -ex
 #sudo apt-get install -y docker.io
 #sudo apt-get install -y postgresql-client
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 sudo chmod 777 *
 

--- a/pg_duckdb_parquet/benchmark.sh
+++ b/pg_duckdb_parquet/benchmark.sh
@@ -6,7 +6,7 @@ set -ex
 #sudo apt-get install -y docker.io
 #sudo apt-get install -y postgresql-client
 
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 sudo docker run -d --name pgduck -p 5432:5432 -e POSTGRES_PASSWORD=duckdb -v ./hits.parquet:/tmp/hits.parquet pgduckdb/pgduckdb:17-v0.3.1 -c duckdb.max_memory=10GB
 
 sleep 5

--- a/pg_mooncake/benchmark.sh
+++ b/pg_mooncake/benchmark.sh
@@ -11,7 +11,7 @@ newgrp docker
 sudo apt-get install -y postgresql-client
 
 
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 docker run -d --name pg_mooncake -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -v ./hits.parquet:/tmp/hits.parquet mooncakelabs/pg_mooncake:17-v0.1.0
 
 sleep 5

--- a/pinot/benchmark.sh
+++ b/pinot/benchmark.sh
@@ -17,7 +17,7 @@ sleep 30
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 # Pinot was unable to load data as a single file wihout any errors returned. We have to split the data

--- a/polars/benchmark.sh
+++ b/polars/benchmark.sh
@@ -7,7 +7,7 @@ sudo apt-get install -y python3-pip
 pip install -U --break-system-packages polars
 
 # Download the data
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+wget --continue https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
 
 # Run the queries
 

--- a/postgresql-tuned/benchmark.sh
+++ b/postgresql-tuned/benchmark.sh
@@ -17,7 +17,7 @@ sudo mkdir /benchmark
 sudo chmod 777 /benchmark
 cd /benchmark
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 666 hits.tsv
 

--- a/postgresql/benchmark.sh
+++ b/postgresql/benchmark.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 sudo apt-get install -y postgresql-common
 sudo apt-get install -y postgresql-14
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 777 ~ hits.tsv
 

--- a/questdb/benchmark.sh
+++ b/questdb/benchmark.sh
@@ -17,7 +17,7 @@ questdb/bin/questdb.sh start
 
 # Import the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 curl -G --data-urlencode "query=$(cat create.sql)" 'http://localhost:9000/exec'

--- a/selectdb/benchmark.sh
+++ b/selectdb/benchmark.sh
@@ -15,7 +15,7 @@ fi
 file_name="$(basename ${url})"
 if [[ "$url" == "http"* ]]; then
     if [[ ! -f $file_name ]]; then
-        wget --no-verbose --continue ${url}
+        wget --continue ${url}
     else
         echo "$file_name already exists, no need to download."
     fi
@@ -89,7 +89,7 @@ mysql -h 127.0.0.1 -P9030 -uroot hits <"$ROOT"/create.sql
 
 # Download data
 if [[ ! -f hits.tsv.gz ]] && [[ ! -f hits.tsv ]]; then
-    wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+    wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
     gzip -d hits.tsv.gz
 fi
 

--- a/singlestore/benchmark.sh
+++ b/singlestore/benchmark.sh
@@ -21,7 +21,7 @@ sudo docker exec -it memsql-ciab memsql -p"${ROOT_PASSWORD}"
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 sudo docker cp hits.tsv memsql-ciab:/
 

--- a/spark/benchmark.sh
+++ b/spark/benchmark.sh
@@ -12,7 +12,7 @@ pip install --break-system-packages pyspark psutil
 
 # Load the data
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
 
 # Run the queries
 

--- a/sqlite/benchmark.sh
+++ b/sqlite/benchmark.sh
@@ -5,7 +5,7 @@ sudo apt-get install -y sqlite3
 
 sqlite3 mydb < create.sql
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
 gzip -d hits.csv.gz
 
 time sqlite3 mydb '.import --csv hits.csv hits'

--- a/starrocks/benchmark.sh
+++ b/starrocks/benchmark.sh
@@ -38,7 +38,7 @@ sleep 30
 
 # Prepare Data
 cd ../
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 # Create Table

--- a/tablespace/benchmark.sh
+++ b/tablespace/benchmark.sh
@@ -6,7 +6,7 @@ PASSWORD="<tablespace-db-password>"
 sudo apt-get update
 sudo apt-get install -y postgresql-client
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 777 ~ hits.tsv
 

--- a/tembo-olap/benchmark.sh
+++ b/tembo-olap/benchmark.sh
@@ -6,7 +6,7 @@ PASSWORD="<password>"
 sudo apt-get update
 sudo apt-get install -y postgresql-client
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 777 ~ hits.tsv
 

--- a/timescale-cloud/README.md
+++ b/timescale-cloud/README.md
@@ -9,7 +9,7 @@
 1. Once the service is ready use the provided connection string to import the dataset:  
 
    ```bash
-   wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+   wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
    gzip -d hits.tsv.gz
    
    export $CONNECTION_STRING=...  

--- a/timescaledb-no-columnstore/benchmark.sh
+++ b/timescaledb-no-columnstore/benchmark.sh
@@ -16,7 +16,7 @@ sudo systemctl restart postgresql
 sudo -u postgres psql -c "CREATE DATABASE nocolumnstore"
 sudo -u postgres psql nocolumnstore -c "CREATE EXTENSION timescaledb WITH VERSION '2.17.2';"
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 sudo chmod og+rX ~
 chmod 777 hits.tsv

--- a/timescaledb/benchmark.sh
+++ b/timescaledb/benchmark.sh
@@ -17,7 +17,7 @@ sudo -u postgres psql -c "CREATE DATABASE test"
 sudo -u postgres psql test -c "CREATE EXTENSION timescaledb WITH VERSION '2.17.2';"
 
 # Import the data
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 sudo chmod og+rX ~
 chmod 777 hits.tsv

--- a/umbra/benchmark.sh
+++ b/umbra/benchmark.sh
@@ -8,12 +8,12 @@ sudo apt-get install -y postgresql-client gzip
 # yum install nc postgresql15
 
 rm -rf hits.tsv
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 chmod 777 hits.tsv
 
 rm -rf umbra-25-01-23.tar.xz umbra
-wget --no-verbose --continue 'https://db.in.tum.de/~schmidt/umbra-2025-01-23.tar.xz'
+wget --continue 'https://db.in.tum.de/~schmidt/umbra-2025-01-23.tar.xz'
 tar -xf umbra-2025-01-23.tar.xz
 
 rm -rf db

--- a/ursa/benchmark.sh
+++ b/ursa/benchmark.sh
@@ -17,7 +17,7 @@ done
 
 ./ursa client < create.sql
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 ./ursa client --time --query "INSERT INTO hits FORMAT TSV" < hits.tsv

--- a/vertica/benchmark.sh
+++ b/vertica/benchmark.sh
@@ -7,7 +7,7 @@ sudo docker run -p 5433:5433 -p 5444:5444 --volume $(pwd):/workdir --mount type=
 
 sudo docker exec vertica_ce /opt/vertica/bin/vsql -U dbadmin -c "$(cat create.sql)"
 
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+wget --continue 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 gzip -d hits.tsv.gz
 
 time sudo docker exec vertica_ce /opt/vertica/bin/vsql -U dbadmin -c "COPY hits FROM LOCAL '/workdir/hits.tsv' DELIMITER E'\\t' NULL E'\\001' DIRECT"

--- a/victorialogs/benchmark.sh
+++ b/victorialogs/benchmark.sh
@@ -13,7 +13,7 @@ done
 rm -rf victoria-logs-data
 
 # Download and start victorialogs
-wget --no-verbose --continue https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${RELEASE_VERSION}/victoria-logs-linux-amd64-${RELEASE_VERSION}.tar.gz
+wget --continue https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${RELEASE_VERSION}/victoria-logs-linux-amd64-${RELEASE_VERSION}.tar.gz
 tar xzf victoria-logs-linux-amd64-${RELEASE_VERSION}.tar.gz
 ./victoria-logs-prod -loggerOutput=stdout -retentionPeriod=20y -search.maxQueryDuration=5m > server.log &
 
@@ -25,7 +25,7 @@ done
 
 # Load the data
 
-wget --no-verbose --continue https://datasets.clickhouse.com/hits_compatible/hits.json.gz
+wget --continue https://datasets.clickhouse.com/hits_compatible/hits.json.gz
 gunzip hits.json.gz
 time cat hits.json | split -n r/8 -d --filter="curl -T - -X POST 'http://localhost:9428/insert/jsonline?_time_field=EventTime&_stream_fields=AdvEngineID,CounterID'"
 


### PR DESCRIPTION
It is nicer to be able to see the progress of downloads (fetching large datasets can easily take 10 minutes).