### PR TITLE
CrateDB: Fix naming for tuned results

### DIFF
--- a/cratedb/results/c6a.4xlarge-tuned.json
+++ b/cratedb/results/c6a.4xlarge-tuned.json
@@ -1,5 +1,5 @@
 {
-    "system": "CrateDB",
+    "system": "CrateDB (tuned)",
     "date": "2025-02-28",
     "machine": "c6a.4xlarge, 500gb gp2",
     "cluster_size": 1,


### PR DESCRIPTION
This is a small fix following #316 where the tuned version wasn't named differently from the standard results.
