### PR TITLE
Fix sed aliasing in `generate-results.sh` for macOS

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -7,6 +7,7 @@
 [ -n "$HOMEBREW_PREFIX" ] && PATH="${HOMEBREW_PREFIX}/opt/coreutils/libexec/gnubin:${PATH}"
 if command -v gsed >/dev/null 2>&1
 then
+    shopt -s expand_aliases
     alias sed='gsed'
 fi
 


### PR DESCRIPTION
By default, aliases are not expanded in bash scripts, meaning the macos `sed` is still being used in the rest of the script even if `gsed` is available.
This change allows aliases to be expanded for the purposes of running this script, verified this behavior and fix on my macbook. 