### PR TITLE
fix generate-results.sh so that it can be run on a mac

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -25,7 +25,7 @@ fi
     done
 
     echo ']; // end of data'
-    sed '0,/^\]; \/\/ end of data$/d' index.html
+    sed -n '/^\]; \/\/ end of data$/,$p' index.html | sed '1d'
 
 ) > index.html.new
 


### PR DESCRIPTION
This is a pretty small change to the generate-results script that makes it so it'll run on a Mac. The sed command there is slightly different and doesn't like range delete command for some reason. I verified that this new version of the command will also work on gnu sed.

