### PR TITLE
Cleanups (2)

### DIFF
--- a/paradedb/results/partitioned.json
+++ b/paradedb/results/partitioned.json
@@ -4,17 +4,9 @@
   "date": "2024-07-13",
   "machine": "c6a.4xlarge",
   "cluster_size": 1,
-    "tuned": "no",
+  "tuned": "no",
   "comment": "",
-
-  "tags": [
-    "Rust",
-    "row-oriented",
-    "column-oriented",
-    "search",
-    "PostgreSQL compatible"
-  ],
-
+  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible"],
   "load_time": 0,
   "data_size": 14779976446,
 

--- a/paradedb/results/single.json
+++ b/paradedb/results/single.json
@@ -4,17 +4,9 @@
   "date": "2024-07-13",
   "machine": "c6a.4xlarge",
   "cluster_size": 1,
-    "tuned": "no",
+  "tuned": "no",
   "comment": "",
-
-  "tags": [
-    "Rust",
-    "row-oriented",
-    "column-oriented",
-    "search",
-    "PostgreSQL compatible"
-  ],
-
+  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible"],
   "load_time": 0,
   "data_size": 14779976446,
 


### PR DESCRIPTION
Every entry must be either column-oriented or row-oriented, depending on the particular run.