### PR TITLE
Make both OSS and proprietary shown by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@ const additional_data_size_points = [
     <tr>
         <th>Open source: </th>
         <td id="selectors_proprietary">
-            <a id="selector-proprietary-yes" class="selector">Yes</a>
+            <a id="selector-proprietary-yes" class="selector selector-active">Yes</a>
             <a id="selector-proprietary-no" class="selector selector-active">No</a>
         </td>
     </tr>
@@ -450,7 +450,7 @@ let selectors = {
     "type": {},
     "machine": {},
     "cluster_size": {},
-    "proprietary": {"yes": true, "no": false},
+    "proprietary": {"yes": true, "no": true},
     "tuned": {"yes": true, "no": false},
     "metric": "hot",
     "queries": [],


### PR DESCRIPTION
They should both be visible on page load.