### PR TITLE
Do not wait indefinitely

### DIFF
--- a/chyt/run.sh
+++ b/chyt/run.sh
@@ -45,7 +45,8 @@ insert_data() {
 }
 
 data_filling_waiting() {
-        while true; do
+        for _ in {1..300}
+        do
                 COUNT=$(yt clickhouse execute --alias *clickbench 'select count(*) as c from `//home/hits`')
                 if [[ "$COUNT" == 99997497 ]]; then
                         yt abort-query $(cat fill_query_id)
@@ -108,7 +109,8 @@ run() {
 }
 
 clique_waiting() {
-        while true; do
+        for _ in {1..300}
+        do
                 if check_ready; then
                         echo "Clique is almost ready. Waiting 1 minute to stabilize"
                         sleep 60

--- a/clickhouse-tencent/benchmark.sh
+++ b/clickhouse-tencent/benchmark.sh
@@ -9,7 +9,7 @@ fi
 
 sudo clickhouse start
 
-while true
+for _ in {1..300}
 do
     clickhouse-client --query "SELECT 1" && break
     sleep 1

--- a/clickhouse-web/benchmark.sh
+++ b/clickhouse-web/benchmark.sh
@@ -9,7 +9,7 @@ curl https://clickhouse.com/ | sh
 sudo ./clickhouse install --noninteractive
 sudo clickhouse start
 
-while true
+for _ in {1..300}
 do
     clickhouse-client --query "SELECT 1" && break
     sleep 1

--- a/clickhouse/benchmark.sh
+++ b/clickhouse/benchmark.sh
@@ -19,7 +19,7 @@ fi;
 
 sudo clickhouse start
 
-while true
+for _ in {1..300}
 do
     clickhouse-client --query "SELECT 1" && break
     sleep 1

--- a/cratedb/benchmark.sh
+++ b/cratedb/benchmark.sh
@@ -28,7 +28,7 @@ sudo apt-get install -y postgresql-client crate
 
 sudo systemctl start crate
 
-while true
+for _ in {1..300}
 do
   psql -U crate -h localhost --no-password -t -c 'SELECT 1' && break
   sleep 1

--- a/doris-parquet/benchmark.sh
+++ b/doris-parquet/benchmark.sh
@@ -48,7 +48,8 @@ ulimit -n 65535
 "$DORIS_HOME"/be/bin/start_be.sh --daemon
 
 # Wait for Frontend ready
-while true; do
+for _ in {1..300}
+do
     fe_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show frontends' | cut -f16 | sed -n '2,$p')
     if [[ -n "${fe_version}" ]] && [[ "${fe_version}" != "NULL" ]]; then
         echo "Frontend version: ${fe_version}"
@@ -63,7 +64,8 @@ done
 mysql -h 127.0.0.1 -P9030 -uroot -e "ALTER SYSTEM ADD BACKEND '127.0.0.1:9050' "
 
 # Wait for Backend ready
-while true; do
+for _ in {1..300}
+do
     be_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show backends' | cut -f22 | sed -n '2,$p')
     if [[ -n "${be_version}" ]]; then
         echo "Backend version: ${be_version}"

--- a/doris/benchmark.sh
+++ b/doris/benchmark.sh
@@ -53,7 +53,8 @@ ulimit -n 65535
 "$DORIS_HOME"/be/bin/start_be.sh --daemon
 
 # Wait for Frontend ready
-while true; do
+for _ in {1..300}
+do
     fe_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show frontends' | cut -f16 | sed -n '2,$p')
     if [[ -n "${fe_version}" ]] && [[ "${fe_version}" != "NULL" ]]; then
         echo "Frontend version: ${fe_version}"
@@ -68,7 +69,8 @@ done
 mysql -h 127.0.0.1 -P9030 -uroot -e "ALTER SYSTEM ADD BACKEND '127.0.0.1:9050' "
 
 # Wait for Backend ready
-while true; do
+for _ in {1..300}
+do
     be_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show backends' | cut -f22 | sed -n '2,$p')
     if [[ -n "${be_version}" ]]; then
         echo "Backend version: ${be_version}"

--- a/hardware/benchmark-chyt.sh
+++ b/hardware/benchmark-chyt.sh
@@ -8,7 +8,8 @@ cat "$QUERIES_FILE" | sed "s|{table}|\"${TABLE}\"|g" | while read -r query; do
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        while true; do
+        for _ in {1..300}
+        do
             RES=$(command time -f %e -o /dev/stdout curl -sS -G --data-urlencode "query=$query" --data "default_format=Null&max_memory_usage=100000000000&max_memory_usage_for_all_queries=100000000000&max_concurrent_queries_for_user=100&database=*$YT_CLIQUE_ID" --location-trusted -H "Authorization: OAuth $YT_TOKEN" "$YT_PROXY.yt.yandex.net/query" 2>/dev/null);
             if [[ $? == 0 ]]; then
                 [[ $RES =~ 'fail|Exception' ]] || break;

--- a/hardware/benchmark-yql.sh
+++ b/hardware/benchmark-yql.sh
@@ -8,7 +8,8 @@ cat "$QUERIES_FILE" | sed "s|{table}|\"${TABLE}\"|g" | while read -r query; do
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        while true; do
+        for _ in {1..300}
+        do
             RES=$(command time -f %e -o time ./yql --clickhouse --syntax-version 1 -f empty <<< "USE chyt.hume; PRAGMA max_memory_usage = 100000000000; PRAGMA max_memory_usage_for_all_queries = 100000000000; $query" >/dev/null 2>&1 && cat time) && break;
         done
 

--- a/selectdb/benchmark.sh
+++ b/selectdb/benchmark.sh
@@ -56,7 +56,8 @@ ulimit -n 65535
 "$DORIS_HOME"/be/bin/start_be.sh --daemon
 
 # Wait for Frontend ready
-while true; do
+for _ in {1..300}
+do
     fe_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show frontends' | cut -f16 | sed -n '2,$p')
     if [[ -n "${fe_version}" ]] && [[ "${fe_version}" != "NULL" ]]; then
         echo "Frontend version: ${fe_version}"
@@ -71,7 +72,8 @@ done
 mysql -h 127.0.0.1 -P9030 -uroot -e "ALTER SYSTEM ADD BACKEND '127.0.0.1:9050' "
 
 # Wait for Backend ready
-while true; do
+for _ in {1..300}
+do
     be_version=$(mysql -h127.0.0.1 -P9030 -uroot -e 'show backends' | cut -f22 | sed -n '2,$p')
     if [[ -n "${be_version}" ]]; then
         echo "Backend version: ${be_version}"

--- a/ursa/benchmark.sh
+++ b/ursa/benchmark.sh
@@ -7,7 +7,7 @@ chmod +x ursa
 
 ./ursa server > server.log 2>&1 &
 
-while true
+for _ in {1..300}
 do
     ./ursa client --query "SELECT 1" && break
     sleep 1

--- a/victorialogs/benchmark.sh
+++ b/victorialogs/benchmark.sh
@@ -5,7 +5,7 @@
 RELEASE_VERSION=v1.10.1-victorialogs
 
 # Stop the existing victorialogs instance if any and drop its data
-while true
+for _ in {1..300}
 do
     pidof victoria-logs-prod && kill `pidof victoria-logs-prod` || break
     sleep 1
@@ -17,7 +17,7 @@ wget --continue --progress=dot:giga https://github.com/VictoriaMetrics/VictoriaM
 tar xzf victoria-logs-linux-$(dpkg --print-architecture)-${RELEASE_VERSION}.tar.gz
 ./victoria-logs-prod -loggerOutput=stdout -retentionPeriod=20y -search.maxQueryDuration=5m > server.log &
 
-while true
+for _ in {1..300}
 do
     curl -s http://localhost:9428/select/logsql/query -d 'query=_time:2100-01-01Z' && break
     sleep 1


### PR DESCRIPTION
Doris, SelectDB, and Starocks fail on smaller machines, but the scripts were written to wait indefinitely.