### PR TITLE
Revert "Add legend for measurement column 2.0"

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,8 +423,7 @@ const additional_data_size_points = [
                 System &amp; Machine
             </th>
             <th colspan="2">
-                Relative <span id="time-or-size">time</span> (lower is better).<br>
-                <span style="font-weight: normal;">Different shades of brown represent the same value at different scales (1x, 10x, 100x zoom).</span>
+                Relative <span id="time-or-size">time</span> (lower is better)
             </th>
         </tr>
     </thead>


### PR DESCRIPTION
Reverts ClickHouse/ClickBench#570

Because the text is factually incorrect:

<img width="1836" height="234" alt="Screenshot_20250817_094430" src="https://github.com/user-attachments/assets/f6c65ba5-ee78-4648-9541-bfc0428a8879" />
