### PR TITLE
fix LogsQL queries

### DIFF
--- a/victorialogs/queries.logsql
+++ b/victorialogs/queries.logsql
@@ -18,10 +18,10 @@ SearchPhrase:* | top 10 (SearchEngineID, SearchPhrase)
 * | by (UserID, SearchPhrase) count() | limit 10
 * | math floor((_time % 1h)/1m) m | top 10 (UserID, m, SearchPhrase)
 UserID:=435090932899640449 | keep UserID
-URL:google | count()
-URL:google SearchPhrase:* | by (SearchPhrase) min(URL), count() c | first 10 (c desc)
-Title:Google -URL:".google." SearchPhrase:* | by (SearchPhrase) min(URL), min(Title), count() c, count_uniq(UserID) | first 10 (c desc)
-URL:google | first 10 (_time)
+URL:*google* | count()
+URL:*google* SearchPhrase:* | by (SearchPhrase) min(URL), count() c | first 10 (c desc)
+Title:*Google* -URL:*.google.* SearchPhrase:* | by (SearchPhrase) min(URL), min(Title), count() c, count_uniq(UserID) | first 10 (c desc)
+URL:*google* | first 10 (_time)
 SearchPhrase:* | first 10 (_time) | keep SearchPhrase
 SearchPhrase:* | first 10 (SearchPhrase) | keep SearchPhrase
 SearchPhrase:* | first 10 (_time, SearchPhrase) | keep SearchPhrase


### PR DESCRIPTION
I was examining some of the substring-heavy queries and I noticed for VictoriaLogs that queries 21-24 differ from the original SQL.

The original uses substring queries:

```sql
SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%';
SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
SELECT * FROM hits WHERE EventTime IN (SELECT EventTime FROM hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10) AND URL LIKE '%google%' ORDER BY EventTime LIMIT 10;
```

However, VictoriaLogs translation was using phrase queries. These actually give different results, for example:

```sh
aduffy@Mac ~/Downloads> curl --fail http://localhost:9428/select/logsql/query --data-urlencode "query=* | count()"
{"count(*)":"99997497"}
aduffy@Mac ~/Downloads> curl --fail http://localhost:9428/select/logsql/query --data-urlencode "query=URL:google | count()"
{"count(*)":"11982"}
aduffy@Mac ~/Downloads> curl --fail http://localhost:9428/select/logsql/query --data-urlencode "query=URL:*google* | count()"
{"count(*)":"15911"}
aduffy@Mac ~/Downloads>
```

Executing the same query in a freshly initialized DuckDB session seems to back up that the proper result here comes from using substring query:


```sql
D CREATE TABLE hits AS select * from read_parquet("parquet/*.parquet");
100% ▕████████████████████████████████████████████████████████████▏
D select count(*) from hits;
┌──────────────────┐
│   count_star()   │
│      int64       │
├──────────────────┤
│     99997497     │
│ (100.00 million) │
└──────────────────┘
D select count(*) from hits where URL LIKE '%google%';
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│    15911     │
└──────────────┘
D
```

Caveat that I do not work on VictoriaLogs so perhaps I got something wrong here!