### PR TITLE
Change default metric to "combined"

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@ let selectors = {
     "cluster_size": {},
     "opensource": {"yes": true, "no": true},
     "tuned": {"no": true, "yes": false},
-    "metric": "hot",
+    "metric": "combined",
     "queries": [],
 };
 


### PR DESCRIPTION
"Combined" as a metric seems less biased than choosing "cold" or "hot" runtimes.