### PR TITLE
fix: sail 0.3.7 build

### DIFF
--- a/sail-partitioned/benchmark.sh
+++ b/sail-partitioned/benchmark.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# https://github.com/rust-lang/rust/issues/97234#issuecomment-1133564556
+ulimit -n 65536
+
 # Install
 
 export DEBIAN_FRONTEND=noninteractive

--- a/sail-partitioned/query.py
+++ b/sail-partitioned/query.py
@@ -18,7 +18,7 @@ import os
 os.environ["SAIL_PARQUET__BINARY_AS_STRING"] = "true"
 os.environ["SAIL_PARQUET__REORDER_FILTERS"] = "true"
 os.environ["SAIL_RUNTIME__ENABLE_SECONDARY"] = "true"
-os.environ["SAIL_PARQUET__ALLOW_SINGLE_FILE_PARALLELISM"] = "true"
+os.environ["SAIL_OPTIMIZER__ENABLE_JOIN_REORDER"] = "true"
 
 server = SparkConnectServer()
 server.start()

--- a/sail/benchmark.sh
+++ b/sail/benchmark.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# https://github.com/rust-lang/rust/issues/97234#issuecomment-1133564556
+ulimit -n 65536
+
 # Install
 
 export DEBIAN_FRONTEND=noninteractive

--- a/sail/query.py
+++ b/sail/query.py
@@ -18,7 +18,7 @@ import os
 os.environ["SAIL_PARQUET__BINARY_AS_STRING"] = "true"
 os.environ["SAIL_PARQUET__REORDER_FILTERS"] = "true"
 os.environ["SAIL_RUNTIME__ENABLE_SECONDARY"] = "true"
-os.environ["SAIL_PARQUET__ALLOW_SINGLE_FILE_PARALLELISM"] = "true"
+os.environ["SAIL_OPTIMIZER__ENABLE_JOIN_REORDER"] = "true"
 
 server = SparkConnectServer()
 server.start()


### PR DESCRIPTION
RE: https://github.com/ClickHouse/ClickBench/pull/632#issuecomment-3385379730

> @shehabgamin, it can't compile: https://pastila.nl/?0007fbb8/2818231301eb0a4beac13d4b6e8bc566#Hz694komZbBtnH3VmQ9eNw==
> 
> Please adjust the script, and we will retry.

@alexey-milovidov I can't reproduce the "Too many open files" error, although I found this:
https://github.com/rust-lang/rust/issues/97234#issuecomment-1133564556

If increasing `ulimit` doesn't fix the issue, we can try removing `env RUSTFLAGS="-C target-cpu=native"` from these two places next:
- https://github.com/ClickHouse/ClickBench/blob/7bc0c7a3547d5e3376d5082b8b1c978540fee056/sail/benchmark.sh#L45
- https://github.com/ClickHouse/ClickBench/blob/7bc0c7a3547d5e3376d5082b8b1c978540fee056/sail-partitioned/benchmark.sh#L45