### PR TITLE
Supabase: Allow using IPv4

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,10 +1,11 @@
 ## Running Supabase Benchmark
 
 ```bash
-$ export PG_PASSWORD="<PASSWORD>"
-$ export SUPABASE_HOST="<HOST>"
+$ export SUPABASE_CONNECTION_STRING="[...]"
 $ ./benchmark.sh
 ```
 
-The Supabase host looks something like: `db.oolfrgytrdoculplvizc.supabase.co`.
-It can be retrieved from the [dashboard](https://supabase.com/docs/guides/troubleshooting/resolving-database-hostname-and-managing-your-ip-address-pVlwE0)
+By default, Supabase requires IPv6 connections.
+This restriction can be bypassed using the "transaction pooler".
+You can get its connection string from the Supabase "Connect to your project" UI.
+It looks something like this: `postgresql://postgres.zlltjtdocmcqiqprpunq:[YOUR-PASSWORD]@aws-1-eu-north-1.pooler.supabase.com:6543/postgres`

--- a/supabase/benchmark.sh
+++ b/supabase/benchmark.sh
@@ -16,8 +16,8 @@ sudo apt-get install -y pigz
 wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
 pigz -d -f hits.tsv.gz
 
-psql -h ${SUPABASE_HOST} -p 5432 -d postgres -U postgres -t -c 'CREATE DATABASE test'
-psql -h ${SUPABASE_HOST} -p 5432 -U postgres -d test -t <create.sql
+psql ${SUPABASE_CONNECTION_STRING} -c 'CREATE DATABASE test'
+psql ${SUPABASE_CONNECTION_STRING} -t <create.sql
 
 echo -n "Load time: "
 command time -f '%e' ./load.sh
@@ -29,6 +29,4 @@ command time -f '%e' ./load.sh
 
 cat log.txt | grep -oP 'Time: \d+\.\d+ ms' | sed -r -e 's/Time: ([0-9]+\.[0-9]+) ms/\1/' |
     awk '{ if (i % 3 == 0) { printf "[" }; printf $1 / 1000; if (i % 3 != 2) { printf "," } else { print "]," }; ++i; }'
-echo
-echo
 echo

--- a/supabase/load.sh
+++ b/supabase/load.sh
@@ -6,7 +6,7 @@ set -eu
 # If we dont' do this, Postgres will throw an error:
 #     "ERROR: cannot perform COPY FREEZE because the table was not created or truncated in the current subtransaction"
 # (i.e. Postgres requires that the table be either created or truncated in the current subtransaction)
-psql -h ${SUPABASE_HOST} -p 5432 -U postgres -d test <<'EOF'
+psql ${SUPABASE_CONNECTION_STRING} <<'EOF'
 set statement_timeout = '60min';
 BEGIN;
 TRUNCATE TABLE hits;
@@ -14,4 +14,4 @@ TRUNCATE TABLE hits;
 COMMIT;
 EOF
 
-psql -h ${SUPABASE_HOST} -p 5432 -U postgres -d test -t -c 'VACUUM ANALYZE hits'
+psql ${SUPABASE_CONNECTION_STRING} -c 'VACUUM ANALYZE hits'

--- a/supabase/run.sh
+++ b/supabase/run.sh
@@ -10,5 +10,5 @@ cat queries.sql | while read -r query; do
     (
         echo '\timing'
         yes "$query" | head -n $TRIES
-    ) | psql -h ${SUPABASE_HOST} -p 5432 -d test -U postgres -t | grep 'Time'
+    ) | psql ${SUPABASE_CONNECTION_STRING} -t | grep 'Time'
 done


### PR DESCRIPTION
I tried to reproduce the new Supabase submission following https://github.com/ClickHouse/ClickBench/pull/564#issuecomment-3420102321

I signed up for the service but then got timeouts when I tried to connect from local `psql`. The reason is that Supabase by default requires IPv6. To fix that one can enable the IPv4 add-on (\+4 $/month) or use a "connection pooler". This PR does the latter.

After fixing this, the data import still failed with

```
ERROR:  could not extend file "base/5/17514.3" with FileFallocate(): No space left on device
HINT:  Check free disk space.
```

... probably because I was only using the free plan.

Anyways, Supabase should now be a bit more reproducible than before.