### PR TITLE
Fix score calculation for Cold/Hot Run tabs in case of <1ms execution times

### DIFF
--- a/gravitons/index.html
+++ b/gravitons/index.html
@@ -561,7 +561,7 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x))));
+            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x != null))));
 
     let summaries = filtered_data.map(elem => {
         const fallback_timing = missing_result_penalty * Math.max(missing_result_time, ...elem.result.map(timings => selectRun(timings)));

--- a/hardware/index.html
+++ b/hardware/index.html
@@ -783,7 +783,7 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x))));
+            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x != null))));
 
     let summaries = filtered_data.map(elem => {
         const fallback_timing = missing_result_penalty * Math.max(missing_result_time, ...elem.result.map(timings => selectRun(timings)));

--- a/index.html
+++ b/index.html
@@ -744,7 +744,7 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x))));
+            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x != null))));
 
     const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x && x > 5));
     const min_data_size = Math.min(...filtered_data.map(elem => elem.data_size).filter(x => x && x > 1e9));

--- a/versions/index.html
+++ b/versions/index.html
@@ -674,7 +674,7 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x))));
+            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x != null))));
 
     let summaries = filtered_data.map(elem => {
         const fallback_timing = missing_result_penalty * Math.max(missing_result_time, ...elem.result.map(timings => selectRun(timings)));


### PR DESCRIPTION
Zero exec times (or <1ms to be more precise) are silently replaced with `Infinity` leading to broken score calculation. In particular, this breaks total ratio calculation as `relativeQueryTime` chokes when it meets an `Infinity` (the `accumulator` value becomes `-Infinity`).

The bug may be seen via this filter: https://benchmark.clickhouse.com/#system=+DcD|QtD&type=-&machine=+ae-l|g-l&cluster_size=-&opensource=-&tuned=+n&metric=hot&queries=-

<img width="1834" height="384" alt="Screenshot from 2025-11-10 21-43-59" src="https://github.com/user-attachments/assets/7fe50eda-8b1d-4e00-b667-c60e0f16b656" />
