### PR TITLE
Tag runs as lukewarm

### DIFF
--- a/arc/results/c6a.2xlarge.json
+++ b/arc/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Python", "column-oriented", "time-series"],
+    "tags": ["Python", "column-oriented", "time-series", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/arc/results/c6a.4xlarge.json
+++ b/arc/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Python", "column-oriented", "time-series"],
+    "tags": ["Python", "column-oriented", "time-series", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/arc/results/c6a.metal.json
+++ b/arc/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Python", "column-oriented", "time-series"],
+    "tags": ["Python", "column-oriented", "time-series", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/arc/results/c8g.metal-48xl.json
+++ b/arc/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Python", "column-oriented", "time-series"],
+    "tags": ["Python", "column-oriented", "time-series", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/arc/template.json
+++ b/arc/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "Python",
     "column-oriented",
-    "time-series"
+    "time-series",
+    "lukewarm-cold-run"
   ]
 }

--- a/byconity/results/c6a.4xlarge.json
+++ b/byconity/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "lukewarm-cold-run"],
 
     "load_time": 343.482,
     "data_size": 14602455235,

--- a/byconity/template.json
+++ b/byconity/template.json
@@ -2,5 +2,5 @@
     "system": "ByConity",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++", "column-oriented", "ClickHouse derivative"]
+    "tags": ["C++", "column-oriented", "ClickHouse derivative","lukewarm-cold-run"]
 }

--- a/chdb-dataframe/results/c6a.metal.json
+++ b/chdb-dataframe/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 101,
     "data_size": 155852128256,
     "result": [

--- a/chdb-dataframe/results/c7a.metal-48xl.json
+++ b/chdb-dataframe/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 78,
     "data_size": 190650941440,
     "result": [

--- a/chdb-dataframe/results/c7i.metal-48xl.json
+++ b/chdb-dataframe/results/c7i.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 140,
     "data_size": 153826500608,
     "result": [

--- a/chdb-dataframe/results/c8g.metal-48xl.json
+++ b/chdb-dataframe/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 72,
     "data_size": 196759048192,
     "result": [

--- a/chdb-dataframe/template.json
+++ b/chdb-dataframe/template.json
@@ -2,5 +2,5 @@
     "system": "chDB (DataFrame)",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe"]
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","Python","dataframe","lukewarm-cold-run"]
 }

--- a/chdb-parquet/results/c6a.2xlarge.json
+++ b/chdb-parquet/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c6a.4xlarge.json
+++ b/chdb-parquet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c6a.large.json
+++ b/chdb-parquet/results/c6a.large.json
@@ -5,7 +5,7 @@
   "cluster_size": 1,
   "proprietary": "no",
   "tuned": "no",
-  "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+  "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
   "load_time": 0,
   "data_size": 14737666736,
   "result": [

--- a/chdb-parquet/results/c6a.metal.json
+++ b/chdb-parquet/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c6a.xlarge.json
+++ b/chdb-parquet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c7a.metal-48xl.json
+++ b/chdb-parquet/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c7i.metal-48xl.json
+++ b/chdb-parquet/results/c7i.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/c8g.4xlarge.json
+++ b/chdb-parquet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":   ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/results/t3a.small.json
+++ b/chdb-parquet/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/chdb-parquet/template.json
+++ b/chdb-parquet/template.json
@@ -2,5 +2,5 @@
     "system": "chDB (Parquet, partitioned)",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"]
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","lukewarm-cold-run"]
 }

--- a/chdb/results/c6a.2xlarge.json
+++ b/chdb/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 561,
     "data_size": 14477033643,
     "result": [

--- a/chdb/results/c6a.4xlarge.json
+++ b/chdb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 516,
     "data_size": 14477072504,
     "result": [

--- a/chdb/results/c6a.large.json
+++ b/chdb/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 818,
     "data_size": 14467595822,
     "result": [

--- a/chdb/results/c6a.metal.json
+++ b/chdb/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 134,
     "data_size": 14469728876,
     "result": [

--- a/chdb/results/c6a.xlarge.json
+++ b/chdb/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 608,
     "data_size": 14465782664,
     "result": [

--- a/chdb/results/c7a.metal-48xl.json
+++ b/chdb/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 121,
     "data_size": 14470455838,
     "result": [

--- a/chdb/results/c7i.metal-48xl.json
+++ b/chdb/results/c7i.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 449,
     "data_size": 14477033643,
     "result": [

--- a/chdb/results/c8g.4xlarge.json
+++ b/chdb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags":   ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 0.063,
     "data_size": 14470258174,
     "result": [

--- a/chdb/results/t3a.small.json
+++ b/chdb/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless", "lukewarm-cold-run"],
     "load_time": 1490,
     "data_size": 14464160379,
     "result": [

--- a/chdb/template.json
+++ b/chdb/template.json
@@ -2,5 +2,5 @@
     "system": "chDB",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless"]
+    "tags": ["C++","column-oriented","ClickHouse derivative","embedded","stateless","serverless","lukewarm-cold-run"]
 }

--- a/chyt/results/yt.192GB_YC.json
+++ b/chyt/results/yt.192GB_YC.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/citus/results/c6a.2xlarge.json
+++ b/citus/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","PostgreSQL compatible","column-oriented"],
+    "tags":   ["C","PostgreSQL compatible","column-oriented", "lukewarm-cold-run"],
     "load_time": 1439,
     "data_size": 18980595583,
     "result": [

--- a/citus/results/c6a.4xlarge.json
+++ b/citus/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C","PostgreSQL compatible","column-oriented"],
+    "tags":  ["C","PostgreSQL compatible","column-oriented", "lukewarm-cold-run"],
     "load_time": 1408,
     "data_size": 18980595583,
     "result": [

--- a/citus/results/c6a.large.json
+++ b/citus/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","PostgreSQL compatible","column-oriented"],
+    "tags":   ["C","PostgreSQL compatible","column-oriented", "lukewarm-cold-run"],
     "load_time": 1714,
     "data_size": 18980595587,
     "result": [

--- a/citus/results/c6a.xlarge.json
+++ b/citus/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","PostgreSQL compatible","column-oriented"],
+    "tags":   ["C","PostgreSQL compatible","column-oriented", "lukewarm-cold-run"],
     "load_time": 1596,
     "data_size": 18980595587,
     "result": [

--- a/citus/template.json
+++ b/citus/template.json
@@ -2,5 +2,5 @@
     "system": "Citus",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C","PostgreSQL compatible","column-oriented"]
+    "tags": ["C","PostgreSQL compatible","column-oriented","lukewarm-cold-run"]
 }

--- a/clickhouse-datalake-partitioned/results/c6a.2xlarge.json
+++ b/clickhouse-datalake-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c6a.4xlarge.json
+++ b/clickhouse-datalake-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c6a.large.json
+++ b/clickhouse-datalake-partitioned/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c6a.metal.json
+++ b/clickhouse-datalake-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c6a.xlarge.json
+++ b/clickhouse-datalake-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c7a.metal-48xl.json
+++ b/clickhouse-datalake-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c8g.4xlarge.json
+++ b/clickhouse-datalake-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/c8g.metal-48xl.json
+++ b/clickhouse-datalake-partitioned/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/results/t3a.small.json
+++ b/clickhouse-datalake-partitioned/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-datalake-partitioned/template.json
+++ b/clickhouse-datalake-partitioned/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "embedded",
     "stateless",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse-datalake/results/c6a.2xlarge.json
+++ b/clickhouse-datalake/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c6a.4xlarge.json
+++ b/clickhouse-datalake/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c6a.large.json
+++ b/clickhouse-datalake/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c6a.metal.json
+++ b/clickhouse-datalake/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c6a.xlarge.json
+++ b/clickhouse-datalake/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c7a.metal-48xl.json
+++ b/clickhouse-datalake/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c8g.4xlarge.json
+++ b/clickhouse-datalake/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/c8g.metal-48xl.json
+++ b/clickhouse-datalake/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/results/t3a.small.json
+++ b/clickhouse-datalake/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-datalake/template.json
+++ b/clickhouse-datalake/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "embedded",
     "stateless",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse-parquet-partitioned/results/c6a.2xlarge.json
+++ b/clickhouse-parquet-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c6a.4xlarge.json
+++ b/clickhouse-parquet-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c6a.large.json
+++ b/clickhouse-parquet-partitioned/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c6a.metal.json
+++ b/clickhouse-parquet-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c6a.xlarge.json
+++ b/clickhouse-parquet-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c7a.metal-48xl.json
+++ b/clickhouse-parquet-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c8g.4xlarge.json
+++ b/clickhouse-parquet-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/c8g.metal-48xl.json
+++ b/clickhouse-parquet-partitioned/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/results/t3a.small.json
+++ b/clickhouse-parquet-partitioned/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/clickhouse-parquet-partitioned/template.json
+++ b/clickhouse-parquet-partitioned/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "embedded",
     "stateless",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse-parquet/results/c6a.2xlarge.json
+++ b/clickhouse-parquet/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c6a.4xlarge.json
+++ b/clickhouse-parquet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c6a.large.json
+++ b/clickhouse-parquet/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c6a.metal.json
+++ b/clickhouse-parquet/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c6a.xlarge.json
+++ b/clickhouse-parquet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c7a.metal-48xl.json
+++ b/clickhouse-parquet/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":     "no",
     "tuned":     "no",
-    "tags":     ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags":     ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c8g.4xlarge.json
+++ b/clickhouse-parquet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/c8g.metal-48xl.json
+++ b/clickhouse-parquet/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/results/t3a.small.json
+++ b/clickhouse-parquet/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","embedded","stateless","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/clickhouse-parquet/template.json
+++ b/clickhouse-parquet/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "embedded",
     "stateless",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse-tencent/results/c6a.2xlarge.json
+++ b/clickhouse-tencent/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 283,
     "data_size": 15250223791,
     "result": [

--- a/clickhouse-tencent/results/c6a.4xlarge.json
+++ b/clickhouse-tencent/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 215,
     "data_size": 15254417942,
     "result": [

--- a/clickhouse-tencent/results/c6a.large.json
+++ b/clickhouse-tencent/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 417,
     "data_size": 15220638021,
     "result": [

--- a/clickhouse-tencent/results/c6a.metal.json
+++ b/clickhouse-tencent/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 7,
     "data_size": 15255139626,
     "result": [

--- a/clickhouse-tencent/results/c6a.xlarge.json
+++ b/clickhouse-tencent/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 321,
     "data_size": 15244103880,
     "result": [

--- a/clickhouse-tencent/results/c7a.metal-48xl.json
+++ b/clickhouse-tencent/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 5,
     "data_size": 15251226785,
     "result": [

--- a/clickhouse-tencent/template.json
+++ b/clickhouse-tencent/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse-web/results/c6a.2xlarge.json
+++ b/clickhouse-web/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c6a.4xlarge.json
+++ b/clickhouse-web/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c6a.metal.json
+++ b/clickhouse-web/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c6a.xlarge.json
+++ b/clickhouse-web/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c7a.metal-48xl.json
+++ b/clickhouse-web/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c8g.4xlarge.json
+++ b/clickhouse-web/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/results/c8g.metal-48xl.json
+++ b/clickhouse-web/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless"],
+    "tags": ["C++","column-oriented","ClickHouse derivative","serverless","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14557009492,
     "result": [

--- a/clickhouse-web/template.json
+++ b/clickhouse-web/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "ClickHouse derivative",
     "serverless",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/clickhouse/results/c6a.2xlarge.json
+++ b/clickhouse/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 291,
     "data_size": 15254019355,
     "result": [

--- a/clickhouse/results/c6a.4xlarge.json
+++ b/clickhouse/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 233,
     "data_size": 15252525142,
     "result": [

--- a/clickhouse/results/c6a.large.json
+++ b/clickhouse/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 440,
     "data_size": 15218606189,
     "result": [

--- a/clickhouse/results/c6a.metal.json
+++ b/clickhouse/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 7,
     "data_size": 15256709483,
     "result": [

--- a/clickhouse/results/c6a.metal.tuned.memory.json
+++ b/clickhouse/results/c6a.metal.tuned.memory.json
@@ -6,7 +6,7 @@
     "comment": "",
     "proprietary": "no",
     "tuned": "yes",
-    "tags": ["C++", "column-oriented", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 284.697,
     "data_size": 82800083772,
     "result": [

--- a/clickhouse/results/c6a.xlarge.json
+++ b/clickhouse/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 341,
     "data_size": 15246160330,
     "result": [

--- a/clickhouse/results/c7a.metal-48xl.json
+++ b/clickhouse/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 5,
     "data_size": 15252391300,
     "result": [

--- a/clickhouse/results/c8g.4xlarge.json
+++ b/clickhouse/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 239,
     "data_size": 15255461023,
     "result": [

--- a/clickhouse/results/c8g.metal-48xl.json
+++ b/clickhouse/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 5,
     "data_size": 15247502708,
     "result": [

--- a/clickhouse/template.json
+++ b/clickhouse/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/cloudberry/results/c6a.4xlarge.json
+++ b/cloudberry/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "14 segments, ORCA enabled",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 601,
     "data_size": 36000000000,

--- a/cloudberry/template.json
+++ b/cloudberry/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/cockroachdb/results/c6a.4xlarge.json
+++ b/cockroachdb/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "CockroachDB v25.1.6. Cache size: 25%.",
 
-    "tags": ["Go", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["Go", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 813,
     "data_size": 67948956585,

--- a/cockroachdb/results/c8g.4xlarge.json
+++ b/cockroachdb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Go", "row-oriented", "PostgreSQL compatible"],
+    "tags":  ["Go", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 760,
     "data_size": 67948956585,
     "result": [

--- a/cockroachdb/template.json
+++ b/cockroachdb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "Go",
     "row-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/cratedb/results/c6a.2xlarge.json
+++ b/cratedb/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented"],
+    "tags":   ["Java","column-oriented", "lukewarm-cold-run"],
     "load_time": 10486,
     "data_size": 55329491303,
     "result": [

--- a/cratedb/results/c6a.4xlarge-tuned.json
+++ b/cratedb/results/c6a.4xlarge-tuned.json
@@ -7,7 +7,7 @@
     "tuned": "yes",
     "comment": "CrateDB 5.10.2. Some queries exceed the available heap space (CircuitBreakingException).",
 
-    "tags": ["Java", "column-oriented"],
+    "tags": ["Java", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 5898,
     "data_size": 55790594831,

--- a/cratedb/results/c6a.4xlarge.json
+++ b/cratedb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java","column-oriented"],
+    "tags":  ["Java","column-oriented", "lukewarm-cold-run"],
     "load_time": 5891,
     "data_size": 59620541258,
     "result": [

--- a/cratedb/results/c6a.xlarge.json
+++ b/cratedb/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented"],
+    "tags":   ["Java","column-oriented", "lukewarm-cold-run"],
     "load_time": 35643,
     "data_size": 55406110686,
     "result": [

--- a/cratedb/results/c8g.4xlarge.json
+++ b/cratedb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented"],
+    "tags":   ["Java","column-oriented", "lukewarm-cold-run"],
     "load_time": 3696,
     "data_size": 60854888525,
     "result": [

--- a/cratedb/template.json
+++ b/cratedb/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Java",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/daft-parquet-partitioned/results/c6a.2xlarge.json
+++ b/daft-parquet-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c6a.4xlarge.json
+++ b/daft-parquet-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c6a.large.json
+++ b/daft-parquet-partitioned/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c6a.metal.json
+++ b/daft-parquet-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c6a.xlarge.json
+++ b/daft-parquet-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c7a.metal-48xl.json
+++ b/daft-parquet-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","stateless","serverless","embedded"],
+    "tags":  ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/c8g.4xlarge.json
+++ b/daft-parquet-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","stateless","serverless","embedded"],
+    "tags":   ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/results/t3a.small.json
+++ b/daft-parquet-partitioned/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/daft-parquet-partitioned/template.json
+++ b/daft-parquet-partitioned/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "stateless",
     "serverless",
-    "embedded"
+    "embedded",
+    "lukewarm-cold-run"
   ]
 }

--- a/daft-parquet/results/c6a.2xlarge.json
+++ b/daft-parquet/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c6a.4xlarge.json
+++ b/daft-parquet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c6a.large.json
+++ b/daft-parquet/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c6a.metal.json
+++ b/daft-parquet/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c6a.xlarge.json
+++ b/daft-parquet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c7a.metal-48xl.json
+++ b/daft-parquet/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","stateless","serverless","embedded"],
+    "tags":  ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/c8g.4xlarge.json
+++ b/daft-parquet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","stateless","serverless","embedded"],
+    "tags":   ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/results/t3a.small.json
+++ b/daft-parquet/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","stateless","serverless","embedded"],
+    "tags": ["Rust","stateless","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/daft-parquet/template.json
+++ b/daft-parquet/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "stateless",
     "serverless",
-    "embedded"
+    "embedded",
+    "lukewarm-cold-run"
   ]
 }

--- a/databend/results/c6a.4xlarge.json
+++ b/databend/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","column-oriented","ClickHouse derivative"],
+    "tags": ["Rust","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 391,
     "data_size": 20917361982,
     "result": [

--- a/databend/results/c6a.metal.json
+++ b/databend/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust","column-oriented","ClickHouse derivative"],
+    "tags": ["Rust","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 77,
     "data_size": 21023288089,
     "result": [

--- a/databend/results/c7a.metal-48xl.json
+++ b/databend/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","column-oriented","ClickHouse derivative"],
+    "tags":  ["Rust","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 95,
     "data_size": 21023325803,
     "result": [

--- a/databend/template.json
+++ b/databend/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "Rust",
     "column-oriented",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/datafusion-partitioned/results/c6a.2xlarge.json
+++ b/datafusion-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/datafusion-partitioned/results/c6a.4xlarge.json
+++ b/datafusion-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","column-oriented","embedded","stateless"],
+    "tags":  ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/datafusion-partitioned/results/c6a.xlarge.json
+++ b/datafusion-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/datafusion-partitioned/results/c8g.4xlarge.json
+++ b/datafusion-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/datafusion-partitioned/template.json
+++ b/datafusion-partitioned/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/datafusion-vortex-partitioned/results/c6a.2xlarge.json
+++ b/datafusion-vortex-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 2025,
     "data_size": 16030812776,
     "result": [

--- a/datafusion-vortex-partitioned/results/c6a.4xlarge.json
+++ b/datafusion-vortex-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","column-oriented","embedded","stateless"],
+    "tags":  ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 208.63,
     "data_size": 15812419580,
     "result": [

--- a/datafusion-vortex-partitioned/results/c6a.xlarge.json
+++ b/datafusion-vortex-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 2025,
     "data_size": 16030812776,
     "result": [

--- a/datafusion-vortex-partitioned/results/c8g.4xlarge.json
+++ b/datafusion-vortex-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 2025,
     "data_size": 16030812776,
     "result": [

--- a/datafusion-vortex-partitioned/template.json
+++ b/datafusion-vortex-partitioned/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/datafusion-vortex/results/c6a.4xlarge.json
+++ b/datafusion-vortex/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","column-oriented","embedded","stateless"],
+    "tags":  ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 2025,
     "data_size": 16030812776,
     "result": [

--- a/datafusion-vortex/template.json
+++ b/datafusion-vortex/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/datafusion/results/c6a.2xlarge.json
+++ b/datafusion/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/datafusion/results/c6a.4xlarge.json
+++ b/datafusion/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust","column-oriented","embedded","stateless"],
+    "tags":  ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/datafusion/results/c6a.xlarge.json
+++ b/datafusion/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/datafusion/results/c8g.4xlarge.json
+++ b/datafusion/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Rust","column-oriented","embedded","stateless"],
+    "tags":   ["Rust","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/datafusion/template.json
+++ b/datafusion/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/doris-parquet/results/c6a.4xlarge.json
+++ b/doris-parquet/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/doris-parquet/template.json
+++ b/doris-parquet/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "MySQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/doris/results/c6a.2xlarge.json
+++ b/doris/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 665,
     "data_size": 16360275237,
     "result": [

--- a/doris/results/c6a.4xlarge.json
+++ b/doris/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 475,
     "data_size": 17105042742,
     "result": [

--- a/doris/results/c6a.metal.json
+++ b/doris/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 408,
     "data_size": 17361426786,
     "result": [

--- a/doris/results/c7a.metal-48xl.json
+++ b/doris/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 363,
     "data_size": 17361427232,
     "result": [

--- a/doris/template.json
+++ b/doris/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "MySQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/drill/results/c6a.2xlarge.json
+++ b/drill/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented","stateless"],
+    "tags":   ["Java","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/drill/results/c6a.4xlarge.json
+++ b/drill/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java","column-oriented","stateless"],
+    "tags":  ["Java","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/drill/template.json
+++ b/drill/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "Java",
     "column-oriented",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/druid/results/c6a.4xlarge.json
+++ b/druid/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "Druid is killed and restarted after every query. Otherwise some queries make Druid degraded and results are incorrect. For example after Q13 even SELECT 1 works for 7 seconds",
 
-    "tags": ["Java", "column-oriented"],
+    "tags": ["Java", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 19620,
     "data_size": 45188608472,

--- a/druid/template.json
+++ b/druid/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Java",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-dataframe/results/c6a.metal.json
+++ b/duckdb-dataframe/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","Python","dataframe"],
+    "tags": ["C++","column-oriented","embedded","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 82,
     "data_size": 182961963008,
     "result": [

--- a/duckdb-dataframe/results/c7a.metal-48xl.json
+++ b/duckdb-dataframe/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","Python","dataframe"],
+    "tags": ["C++","column-oriented","embedded","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 93,
     "data_size": 175929663488,
     "result": [

--- a/duckdb-dataframe/results/c8g.metal-48xl.json
+++ b/duckdb-dataframe/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","Python","dataframe"],
+    "tags": ["C++","column-oriented","embedded","Python","dataframe", "lukewarm-cold-run"],
     "load_time": 73,
     "data_size": 176077402112,
     "result": [

--- a/duckdb-dataframe/template.json
+++ b/duckdb-dataframe/template.json
@@ -7,6 +7,7 @@
     "column-oriented",
     "embedded",
     "Python",
-    "dataframe"
+    "dataframe",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-datalake-partitioned/results/c6a.2xlarge.json
+++ b/duckdb-datalake-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c6a.4xlarge.json
+++ b/duckdb-datalake-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c6a.metal.json
+++ b/duckdb-datalake-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c6a.xlarge.json
+++ b/duckdb-datalake-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c7a.metal-48xl.json
+++ b/duckdb-datalake-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c8g.4xlarge.json
+++ b/duckdb-datalake-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/results/c8g.metal-48xl.json
+++ b/duckdb-datalake-partitioned/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-datalake-partitioned/template.json
+++ b/duckdb-datalake-partitioned/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-datalake/results/c6a.2xlarge.json
+++ b/duckdb-datalake/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c6a.4xlarge.json
+++ b/duckdb-datalake/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c6a.metal.json
+++ b/duckdb-datalake/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c6a.xlarge.json
+++ b/duckdb-datalake/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c7a.metal-48xl.json
+++ b/duckdb-datalake/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c8g.4xlarge.json
+++ b/duckdb-datalake/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/results/c8g.metal-48xl.json
+++ b/duckdb-datalake/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-datalake/template.json
+++ b/duckdb-datalake/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-memory/results/c6a.2xlarge.json
+++ b/duckdb-memory/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 426,
     "data_size": 14791049216,
     "result": [

--- a/duckdb-memory/results/c6a.4xlarge.json
+++ b/duckdb-memory/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 283,
     "data_size": 28254740480,
     "result": [

--- a/duckdb-memory/results/c6a.metal.json
+++ b/duckdb-memory/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 15,
     "data_size": 109959671808,
     "result": [

--- a/duckdb-memory/results/c7a.metal-48xl.json
+++ b/duckdb-memory/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 12,
     "data_size": 110490939392,
     "result": [

--- a/duckdb-memory/results/c8g.4xlarge.json
+++ b/duckdb-memory/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 288,
     "data_size": 27818287104,
     "result": [

--- a/duckdb-memory/results/c8g.metal-48xl.json
+++ b/duckdb-memory/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 13,
     "data_size": 107791679488,
     "result": [

--- a/duckdb-memory/template.json
+++ b/duckdb-memory/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "embedded"
+    "embedded",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-parquet-partitioned/results/c6a.2xlarge.json
+++ b/duckdb-parquet-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c6a.4xlarge.json
+++ b/duckdb-parquet-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c6a.large.json
+++ b/duckdb-parquet-partitioned/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c6a.metal.json
+++ b/duckdb-parquet-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c6a.xlarge.json
+++ b/duckdb-parquet-partitioned/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 1,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c7a.metal-48xl.json
+++ b/duckdb-parquet-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c8g.4xlarge.json
+++ b/duckdb-parquet-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/results/c8g.metal-48xl.json
+++ b/duckdb-parquet-partitioned/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/duckdb-parquet-partitioned/template.json
+++ b/duckdb-parquet-partitioned/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-parquet/results/c6a.2xlarge.json
+++ b/duckdb-parquet/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c6a.4xlarge.json
+++ b/duckdb-parquet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c6a.large.json
+++ b/duckdb-parquet/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 1,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c6a.metal.json
+++ b/duckdb-parquet/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c6a.xlarge.json
+++ b/duckdb-parquet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c7a.metal-48xl.json
+++ b/duckdb-parquet/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c8g.4xlarge.json
+++ b/duckdb-parquet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/c8g.metal-48xl.json
+++ b/duckdb-parquet/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/results/t3a.small.json
+++ b/duckdb-parquet/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded","stateless"],
+    "tags": ["C++","column-oriented","embedded","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/duckdb-parquet/template.json
+++ b/duckdb-parquet/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-vortex-partitioned/results/c6a.4xlarge.json
+++ b/duckdb-vortex-partitioned/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["Rust", "column-oriented", "embedded", "stateless"],
+    "tags": ["Rust", "column-oriented", "embedded", "stateless", "lukewarm-cold-run"],
 
     "load_time": 742.26,
     "data_size": 15961049404,

--- a/duckdb-vortex-partitioned/template.json
+++ b/duckdb-vortex-partitioned/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb-vortex/results/c6a.4xlarge.json
+++ b/duckdb-vortex/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["Rust", "column-oriented", "embedded", "stateless"],
+    "tags": ["Rust", "column-oriented", "embedded", "stateless", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 17138413352,

--- a/duckdb-vortex/template.json
+++ b/duckdb-vortex/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "embedded",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/duckdb/results/c6a.2xlarge.json
+++ b/duckdb/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 148,
     "data_size": 20548956160,
     "result": [

--- a/duckdb/results/c6a.4xlarge.json
+++ b/duckdb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 119,
     "data_size": 20550266880,
     "result": [

--- a/duckdb/results/c6a.large.json
+++ b/duckdb/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 846,
     "data_size": 23642517504,
     "result": [

--- a/duckdb/results/c6a.metal.json
+++ b/duckdb/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 103,
     "data_size": 20559441920,
     "result": [

--- a/duckdb/results/c6a.xlarge.json
+++ b/duckdb/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 250,
     "data_size": 20548431872,
     "result": [

--- a/duckdb/results/c7a.metal-48xl.json
+++ b/duckdb/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 97,
     "data_size": 20559179776,
     "result": [

--- a/duckdb/results/c8g.4xlarge.json
+++ b/duckdb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 113,
     "data_size": 20548431872,
     "result": [

--- a/duckdb/results/c8g.metal-48xl.json
+++ b/duckdb/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","embedded"],
+    "tags": ["C++","column-oriented","embedded", "lukewarm-cold-run"],
     "load_time": 95,
     "data_size": 20559966208,
     "result": [

--- a/duckdb/template.json
+++ b/duckdb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "embedded"
+    "embedded",
+    "lukewarm-cold-run"
   ]
 }

--- a/elasticsearch/results/c6a.4xlarge.json
+++ b/elasticsearch/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","search"],
+    "tags": ["Java","search", "lukewarm-cold-run"],
     "load_time": 9531,
     "data_size": 85859504096,
     "result": [

--- a/elasticsearch/results/c6a.4xlarge.tuned.json
+++ b/elasticsearch/results/c6a.4xlarge.tuned.json
@@ -7,7 +7,7 @@
     "tuned": "yes",
     "comment": "Tuned by repeated benchmark to find the optimal Elasticsearch shard number and size for this resource type and workload",
 
-    "tags": ["Java", "search"],
+    "tags": ["Java", "search", "lukewarm-cold-run"],
 
     "load_time": 7139.561,
     "data_size": 114316150384,

--- a/elasticsearch/results/c6a.metal.json
+++ b/elasticsearch/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","search"],
+    "tags": ["Java","search", "lukewarm-cold-run"],
     "load_time": 9565,
     "data_size": 84661395365,
     "result": [

--- a/elasticsearch/template.json
+++ b/elasticsearch/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Java",
-    "search"
+    "search",
+    "lukewarm-cold-run"
   ]
 }

--- a/firebolt/results/c6a.2xlarge.json
+++ b/firebolt/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 264,
     "data_size": 15720404801,
     "result": [

--- a/firebolt/results/c6a.4xlarge.json
+++ b/firebolt/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 232,
     "data_size": 15711652565,
     "result": [

--- a/firebolt/results/c6a.4xlarge_scan_cache.json
+++ b/firebolt/results/c6a.4xlarge_scan_cache.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "yes",
-    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 418.292,
     "data_size": 15712149035,
     "result": [

--- a/firebolt/results/c6a.metal.json
+++ b/firebolt/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "no",
-    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 189.244,
     "data_size": 15711137296,
     "result": [

--- a/firebolt/results/c6a.metal_scan_cache.json
+++ b/firebolt/results/c6a.metal_scan_cache.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "yes",
-    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "PostgreSQL compatible", "ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 156.778,
     "data_size": 15716159954,
     "result": [

--- a/firebolt/results/c6a.xlarge.json
+++ b/firebolt/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 368,
     "data_size": 15721731790,
     "result": [

--- a/firebolt/results/c7a.metal-48xl.json
+++ b/firebolt/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 199,
     "data_size": 15714722063,
     "result": [

--- a/firebolt/results/c8g.4xlarge.json
+++ b/firebolt/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","lukewarm-cold-run"],
     "load_time": 235,
     "data_size": 15724940400,
     "result": [

--- a/glaredb-partitioned/results/c6a.4xlarge.json
+++ b/glaredb-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["Rust","serverless"],
+    "tags":  ["Rust","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/glaredb-partitioned/results/c8g.4xlarge.json
+++ b/glaredb-partitioned/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["Rust","serverless"],
+    "tags":   ["Rust","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/glaredb-partitioned/template.json
+++ b/glaredb-partitioned/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Rust",
-    "serverless"
+    "serverless",
+    "lukewarm-cold-run"
   ]
 }

--- a/glaredb/results/c6a.4xlarge.json
+++ b/glaredb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["Rust","serverless"],
+    "tags":  ["Rust","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/glaredb/results/c8g.4xlarge.json
+++ b/glaredb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["Rust","serverless"],
+    "tags":   ["Rust","serverless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/glaredb/template.json
+++ b/glaredb/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Rust",
-    "serverless"
+    "serverless",
+    "lukewarm-cold-run"
   ]
 }

--- a/greenplum/results/c6a.4xlarge.json
+++ b/greenplum/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 1080,
     "data_size": 42000000000,

--- a/greenplum/template.json
+++ b/greenplum/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/heavyai/results/c6a.4xlarge.json
+++ b/heavyai/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "Previous names: OmniSci, mapD. Many queries cannot run due to errors and limitations.",
 
-    "tags": ["C++", "column-oriented"],
+    "tags": ["C++", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 572.633,
     "data_size": 50887437386,

--- a/heavyai/template.json
+++ b/heavyai/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "C++",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/hydra/results/hydra.json
+++ b/hydra/results/hydra.json
@@ -5,7 +5,7 @@
     "cluster_size": "serverless",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["managed", "PostgreSQL compatible", "column-oriented"],
+    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "lukewarm-cold-run"],
     "load_time": 136,
     "data_size": 30816390348,
     "result": [

--- a/infobright/results/c6a.4xlarge.json
+++ b/infobright/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "Only 90% of data successfully loaded. Some queries run for days.",
 
-    "tags": ["C++", "column-oriented", "MySQL compatible"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "lukewarm-cold-run"],
 
     "load_time": 2317,
     "data_size": 13760341294,

--- a/infobright/template.json
+++ b/infobright/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/kinetica/results/c6a.4xlarge.json
+++ b/kinetica/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["column-oriented"],
+    "tags":  ["column-oriented", "lukewarm-cold-run"],
     "load_time": 668,
     "data_size": 57932249716,
     "result": [

--- a/kinetica/results/c8g.4xlarge.json
+++ b/kinetica/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["column-oriented"],
+    "tags":   ["column-oriented", "lukewarm-cold-run"],
     "load_time": 655,
     "data_size": 57836683298,
     "result": [

--- a/kinetica/template.json
+++ b/kinetica/template.json
@@ -3,6 +3,7 @@
   "proprietary": "yes",
   "tuned": "no",
   "tags": [
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/mariadb-columnstore/results/c6a.4xlarge.json
+++ b/mariadb-columnstore/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "Previous name: InfiniDB.",
 
-    "tags": ["C++", "column-oriented", "MySQL compatible"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "lukewarm-cold-run"],
 
     "load_time": 2507.8,
     "data_size": 19712857022,

--- a/mariadb-columnstore/template.json
+++ b/mariadb-columnstore/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/mariadb/results/c6a.4xlarge.json
+++ b/mariadb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","row-oriented","MySQL compatible"],
+    "tags":  ["C++","row-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 8875,
     "data_size": 90182376487,
     "result": [

--- a/mariadb/template.json
+++ b/mariadb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "row-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/monetdb/results/c6a.4xlarge.json
+++ b/monetdb/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented"],
+    "tags": ["C", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 939,
     "data_size": 49696606499,

--- a/monetdb/template.json
+++ b/monetdb/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "C",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/mongodb/results/c6a.4xlarge.json
+++ b/mongodb/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["row-oriented", "document", "C++"],
+  "tags": ["row-oriented", "document", "C++", "lukewarm-cold-run"],
 
   "load_time": 44824,
   "data_size": 86397751448,

--- a/mongodb/template.json
+++ b/mongodb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "row-oriented",
     "document",
-    "C++"
+    "C++",
+    "lukewarm-cold-run"
   ]
 }

--- a/mysql-myisam/results/c6a.2xlarge.json
+++ b/mysql-myisam/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","row-oriented","MySQL compatible"],
+    "tags":   ["C++","row-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 1506,
     "data_size": 56422266688,
     "result": [

--- a/mysql-myisam/results/c6a.4xlarge.json
+++ b/mysql-myisam/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","row-oriented","MySQL compatible"],
+    "tags":  ["C++","row-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 1458,
     "data_size": 56422266688,
     "result": [

--- a/mysql-myisam/template.json
+++ b/mysql-myisam/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "row-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/mysql/results/c6a.4xlarge.json
+++ b/mysql/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","row-oriented","MySQL compatible"],
+    "tags":  ["C++","row-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 10004,
     "data_size": 94435803136,
     "result": [

--- a/mysql/template.json
+++ b/mysql/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "row-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/octosql/results/c6a.2xlarge.json
+++ b/octosql/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","stateless"],
+    "tags":   ["Go","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/octosql/results/c6a.4xlarge.json
+++ b/octosql/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Go","stateless"],
+    "tags":  ["Go","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/octosql/results/c6a.large.json
+++ b/octosql/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","stateless"],
+    "tags":   ["Go","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/octosql/results/c6a.xlarge.json
+++ b/octosql/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","stateless"],
+    "tags":   ["Go","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/octosql/results/t3a.small.json
+++ b/octosql/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","stateless"],
+    "tags":   ["Go","stateless", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/octosql/template.json
+++ b/octosql/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Go",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/opteryx/results/c6a.2xlarge.json
+++ b/opteryx/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["stateless","column-oriented","serverless","embedded"],
+    "tags":   ["stateless","column-oriented","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/opteryx/results/c6a.4xlarge.json
+++ b/opteryx/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["stateless","column-oriented","serverless","embedded"],
+    "tags":  ["stateless","column-oriented","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/opteryx/results/c6a.xlarge.json
+++ b/opteryx/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["stateless","column-oriented","serverless","embedded"],
+    "tags":   ["stateless","column-oriented","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/opteryx/results/t3a.small.json
+++ b/opteryx/results/t3a.small.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["stateless","column-oriented","serverless","embedded"],
+    "tags":   ["stateless","column-oriented","serverless","embedded", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/opteryx/template.json
+++ b/opteryx/template.json
@@ -6,6 +6,7 @@
     "stateless",
     "column-oriented",
     "serverless",
-    "embedded"
+    "embedded",
+    "lukewarm-cold-run"
   ]
 }

--- a/oxla/results/c6a.2xlarge.json
+++ b/oxla/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C"],
+    "tags":   ["C", "lukewarm-cold-run"],
     "load_time": 764,
     "data_size": 17820866692,
     "result": [

--- a/oxla/results/c6a.4xlarge.json
+++ b/oxla/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["C"],
+    "tags":  ["C", "lukewarm-cold-run"],
     "load_time": 632,
     "data_size": 17823718769,
     "result": [

--- a/oxla/results/c8g.4xlarge.json
+++ b/oxla/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C"],
+    "tags":   ["C", "lukewarm-cold-run"],
     "load_time": 633,
     "data_size": 17822504987,
     "result": [

--- a/oxla/template.json
+++ b/oxla/template.json
@@ -3,6 +3,7 @@
   "proprietary": "yes",
   "tuned": "no",
   "tags": [
-    "C"
+    "C",
+    "lukewarm-cold-run"
   ]
 }

--- a/pandas/results/c6a.metal.json
+++ b/pandas/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["C++", "column-oriented", "embedded", "stateless", "serverless", "dataframe"],
+    "tags": ["C++", "column-oriented", "embedded", "stateless", "serverless", "dataframe", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 46998823718,
     "result": [

--- a/pandas/template.json
+++ b/pandas/template.json
@@ -2,5 +2,5 @@
     "system": "pandas",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Python","dataframe","row-oriented"]
+    "tags": ["Python","dataframe","row-oriented", "lukewarm-cold-run"]
 }

--- a/paradedb-partitioned/results/c6a.4xlarge.json
+++ b/paradedb-partitioned/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
   "tuned": "no",
   "comment": "",
-  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible"],
+  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible", "lukewarm-cold-run"],
   "load_time": 0,
   "data_size": 14779976446,
 

--- a/paradedb-partitioned/template.json
+++ b/paradedb-partitioned/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "search",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/paradedb/results/c6a.4xlarge.json
+++ b/paradedb/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
   "proprietary": "no",
   "tuned": "no",
   "comment": "",
-  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible"],
+  "tags": ["Rust", "column-oriented", "search", "PostgreSQL compatible", "lukewarm-cold-run"],
   "load_time": 0,
   "data_size": 14779976446,
 

--- a/paradedb/results/c8g.4xlarge.json
+++ b/paradedb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Rust", "column-oriented", "search", "PostgreSQL compatible"],
+    "tags":  ["Rust", "column-oriented", "search", "PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/paradedb/template.json
+++ b/paradedb/template.json
@@ -6,6 +6,7 @@
     "Rust",
     "column-oriented",
     "search",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/parseable/results/c6a.4xlarge.json
+++ b/parseable/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "v1.7.5 (6e5242f)",
 
-    "tags": ["Rust", "column-oriented"],
+    "tags": ["Rust", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 14018794333,

--- a/parseable/results/c6a.metal.json
+++ b/parseable/results/c6a.metal.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "v1.7.5 (6e5242f)",
 
-    "tags": ["Rust", "column-oriented"],
+    "tags": ["Rust", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 14018794333,

--- a/parseable/template.json
+++ b/parseable/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Rust",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/pg_duckdb-indexed/results/c6a.4xlarge.json
+++ b/pg_duckdb-indexed/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
 
-    "tags": ["column-oriented", "PostgreSQL compatible"],
+    "tags": ["column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 10762,
     "data_size": 123194382472,

--- a/pg_duckdb-indexed/template.json
+++ b/pg_duckdb-indexed/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/pg_duckdb-motherduck/results/motherduck.json
+++ b/pg_duckdb-motherduck/results/motherduck.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented", "PostgreSQL compatible", "serverless"],
+    "tags": ["managed", "column-oriented", "PostgreSQL compatible", "serverless", "lukewarm-cold-run"],
 
     "load_time": 118.616,
     "data_size": 26306674688,

--- a/pg_duckdb/results/c6a.2xlarge.json
+++ b/pg_duckdb/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 1012,
     "data_size": 106482567305,
     "result": [

--- a/pg_duckdb/results/c6a.4xlarge.json
+++ b/pg_duckdb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["column-oriented","PostgreSQL compatible"],
+    "tags":  ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 1003,
     "data_size": 106482563210,
     "result": [

--- a/pg_duckdb/results/c6a.xlarge.json
+++ b/pg_duckdb/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 989,
     "data_size": 106482567304,
     "result": [

--- a/pg_duckdb/results/c8g.4xlarge.json
+++ b/pg_duckdb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 967,
     "data_size": 106482559114,
     "result": [

--- a/pg_duckdb/template.json
+++ b/pg_duckdb/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/pg_duckdb_parquet/results/c6a.2xlarge.json
+++ b/pg_duckdb_parquet/results/c6a.2xlarge.json
@@ -1,11 +1,11 @@
-{
+, "lukewarm-cold-run"{
     "system":   "pg_duckdb (Parquet)",
     "date": "2025-07-10",
     "machine": "c6a.2xlarge",
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14820803219,
     "result": [

--- a/pg_duckdb_parquet/results/c6a.4xlarge.json
+++ b/pg_duckdb_parquet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["column-oriented","PostgreSQL compatible"],
+    "tags":  ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14820803219,
     "result": [

--- a/pg_duckdb_parquet/results/c6a.xlarge.json
+++ b/pg_duckdb_parquet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14820803219,
     "result": [

--- a/pg_duckdb_parquet/results/c8g.4xlarge.json
+++ b/pg_duckdb_parquet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","PostgreSQL compatible"],
+    "tags":   ["column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14820803219,
     "result": [

--- a/pg_duckdb_parquet/template.json
+++ b/pg_duckdb_parquet/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/pg_mooncake/results/c6a.2xlarge.json
+++ b/pg_mooncake/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","column-oriented","PostgreSQL compatible"],
+    "tags":   ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 594,
     "data_size": 14623184166,
     "result": [

--- a/pg_mooncake/results/c6a.4xlarge.json
+++ b/pg_mooncake/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C","column-oriented","PostgreSQL compatible"],
+    "tags":  ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 537,
     "data_size": 14623184166,
     "result": [

--- a/pg_mooncake/results/c6a.xlarge.json
+++ b/pg_mooncake/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","column-oriented","PostgreSQL compatible"],
+    "tags":   ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 607,
     "data_size": 14623184166,
     "result": [

--- a/pg_mooncake/results/c8g.4xlarge.json
+++ b/pg_mooncake/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","column-oriented","PostgreSQL compatible"],
+    "tags":   ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 579,
     "data_size": 14623184166,
     "result": [

--- a/pg_mooncake/template.json
+++ b/pg_mooncake/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/pgpro_tam/results/16vCPU.parquet_fmt.fd_smgr.json
+++ b/pgpro_tam/results/16vCPU.parquet_fmt.fd_smgr.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 896,
     "data_size": 9690683705,

--- a/pgpro_tam/results/16vCPU.parquet_fmt.fd_smgr.parallel.json
+++ b/pgpro_tam/results/16vCPU.parquet_fmt.fd_smgr.parallel.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 231,
     "data_size": 9296839750,

--- a/pgpro_tam/results/16vCPU.parquet_fmt.mem_fd_smgr.json
+++ b/pgpro_tam/results/16vCPU.parquet_fmt.mem_fd_smgr.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 901,
     "data_size": 9690839353,

--- a/pgpro_tam/results/c6a.2xlarge.json
+++ b/pgpro_tam/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C","column-oriented","PostgreSQL compatible"],
+    "tags":   ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 1001,
     "data_size": 9690683705,
     "result": [

--- a/pgpro_tam/results/c6a.4xlarge.json
+++ b/pgpro_tam/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["C","column-oriented","PostgreSQL compatible"],
+    "tags":  ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 984,
     "data_size": 9690683705,
     "result": [

--- a/pgpro_tam/results/c6a.metal.feather_fmt.mem_fd_smgr.json
+++ b/pgpro_tam/results/c6a.metal.feather_fmt.mem_fd_smgr.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 1013,
     "data_size": 70595166439,

--- a/pgpro_tam/results/c6a.metal.parquet_fmt.fd_smgr.json
+++ b/pgpro_tam/results/c6a.metal.parquet_fmt.fd_smgr.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 845,
     "data_size": 9690904889,

--- a/pgpro_tam/results/c6a.metal.parquet_fmt.fd_smgr.parallel.json
+++ b/pgpro_tam/results/c6a.metal.parquet_fmt.fd_smgr.parallel.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 377,
     "data_size": 9296839750,

--- a/pgpro_tam/results/c6a.metal.parquet_fmt.mem_fd_smgr.json
+++ b/pgpro_tam/results/c6a.metal.parquet_fmt.mem_fd_smgr.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 851,
     "data_size": 9675437383,

--- a/pgpro_tam/results/c6a.xlarge.json
+++ b/pgpro_tam/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C","column-oriented","PostgreSQL compatible"],
+    "tags":   ["C","column-oriented","PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 937,
     "data_size": 9690683705,
     "result": [

--- a/pgpro_tam/template.json
+++ b/pgpro_tam/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/pinot/results/c6a.4xlarge.json
+++ b/pinot/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "It successfully loaded only 94465149 out of 99997497 records. Some queries returned NullPointerException. The loading process is painful - splitting to 100 pieces required. It does not correctly report errors on data loading, the results may be incorrect.",
 
-    "tags": ["Java", "column-oriented"],
+    "tags": ["Java", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2032,
     "data_size": null,

--- a/pinot/template.json
+++ b/pinot/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Java",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/polars/results/c6a.4xlarge.json
+++ b/polars/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": null,
     "data_size": 14779976446,
     "result": [

--- a/polars/results/c6a.metal.json
+++ b/polars/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": null,
     "data_size": 14779976446,
     "result": [

--- a/polars/results/c7a.metal-48xl.json
+++ b/polars/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/polars/results/c8g.4xlarge.json
+++ b/polars/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["column-oriented"],
+    "tags":  ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/polars/template.json
+++ b/polars/template.json
@@ -3,6 +3,7 @@
   "proprietary": "no",
   "tuned": "no",
   "tags": [
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/polars_dataframe/results/c6a.2xlarge.json
+++ b/polars_dataframe/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","dataframe"],
+    "tags":   ["column-oriented","dataframe", "lukewarm-cold-run"],
     "load_time": 381,
     "data_size": 15558373376,
     "result": [

--- a/polars_dataframe/results/c6a.4xlarge.json
+++ b/polars_dataframe/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["column-oriented","dataframe"],
+    "tags":  ["column-oriented","dataframe", "lukewarm-cold-run"],
     "load_time": 321,
     "data_size": 31882731520,
     "result": [

--- a/polars_dataframe/results/c6a.metal.json
+++ b/polars_dataframe/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["column-oriented", "dataframe"],
+    "tags": ["column-oriented", "dataframe", "lukewarm-cold-run"],
     "load_time": 2.300,
     "data_size": 14779976446,
     "result": [

--- a/polars_dataframe/results/c6a.xlarge.json
+++ b/polars_dataframe/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","dataframe"],
+    "tags":   ["column-oriented","dataframe", "lukewarm-cold-run"],
     "load_time": 410,
     "data_size": 7457083392,
     "result": [

--- a/polars_dataframe/results/c7a.metal-48xl.json
+++ b/polars_dataframe/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["column-oriented","dataframe"],
+    "tags":  ["column-oriented","dataframe", "lukewarm-cold-run"],
     "load_time": 3,
     "data_size": 182430203904,
     "result": [

--- a/polars_dataframe/results/c8g.4xlarge.json
+++ b/polars_dataframe/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["column-oriented","dataframe"],
+    "tags":   ["column-oriented","dataframe", "lukewarm-cold-run"],
     "load_time": 313,
     "data_size": 32016297984,
     "result": [

--- a/polars_dataframe/template.json
+++ b/polars_dataframe/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "column-oriented",
-    "dataframe"
+    "dataframe",
+    "lukewarm-cold-run"
   ]
 }

--- a/postgresql-indexed/results/c6a.4xlarge.json
+++ b/postgresql-indexed/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "yes",
     "comment": "",
 
-    "tags": ["C", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 10357,
     "data_size": 124386147162,

--- a/postgresql-indexed/template.json
+++ b/postgresql-indexed/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "row-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/postgresql-orioledb/results/c6a.4xlarge.json
+++ b/postgresql-orioledb/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "beta12-pg17",
-    "tags": ["C", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 1751,
     "data_size": 77198718500,
     "result": [

--- a/postgresql-orioledb/template.json
+++ b/postgresql-orioledb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "row-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/postgresql/results/c6a.4xlarge.json
+++ b/postgresql/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 937,
     "data_size": 106489682778,

--- a/postgresql/template.json
+++ b/postgresql/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "row-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/questdb/results/c6a.4xlarge.json
+++ b/questdb/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["Java", "time-series"],
+    "tags": ["Java", "time-series", "lukewarm-cold-run"],
     "load_time": 5427,
     "data_size": 72842171917,
     "result": [

--- a/questdb/results/c6a.metal.json
+++ b/questdb/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "Uses multi-threaded COPY SQL for data load.",
-    "tags": ["Java", "time-series"],
+    "tags": ["Java", "time-series", "lukewarm-cold-run"],
     "load_time": 231,
     "data_size": 72847100025,
     "result": [

--- a/questdb/template.json
+++ b/questdb/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Java",
-    "time-series"
+    "time-series",
+    "lukewarm-cold-run"
   ]
 }

--- a/sail-partitioned/results/c6a.2xlarge.json
+++ b/sail-partitioned/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail-partitioned/results/c6a.4xlarge.json
+++ b/sail-partitioned/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail-partitioned/results/c6a.metal.json
+++ b/sail-partitioned/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail-partitioned/results/c7a.metal-48xl.json
+++ b/sail-partitioned/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail-partitioned/template.json
+++ b/sail-partitioned/template.json
@@ -3,6 +3,7 @@
   "proprietary": "no",
   "tuned": "no",
   "tags": [
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/sail/results/c6a.2xlarge.json
+++ b/sail/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail/results/c6a.4xlarge.json
+++ b/sail/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail/results/c6a.metal.json
+++ b/sail/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail/results/c7a.metal-48xl.json
+++ b/sail/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["column-oriented"],
+    "tags": ["column-oriented", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/sail/template.json
+++ b/sail/template.json
@@ -3,6 +3,7 @@
   "proprietary": "no",
   "tuned": "no",
   "tags": [
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/selectdb/results/c6a.2xlarge.json
+++ b/selectdb/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 716,
     "data_size": 16402424021,
     "result": [

--- a/selectdb/results/c6a.4xlarge.json
+++ b/selectdb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 487,
     "data_size": 17103182575,
     "result": [

--- a/selectdb/results/c6a.metal.json
+++ b/selectdb/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 459,
     "data_size": 17365253189,
     "result": [

--- a/selectdb/results/c7a.metal-48xl.json
+++ b/selectdb/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","MySQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 364,
     "data_size": 17361427624,
     "result": [

--- a/selectdb/template.json
+++ b/selectdb/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "MySQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/siglens/results/c6a.4xlarge.json
+++ b/siglens/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "yes",
     "tuned": "no",
-    "tags": ["Go", "search"],
+    "tags": ["Go", "search", "lukewarm-cold-run"],
     "load_time": 5070.66,
     "data_size": 28572908000,
     "result": [

--- a/siglens/template.json
+++ b/siglens/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Go",
-    "search"
+    "search",
+    "lukewarm-cold-run"
   ]
 }

--- a/singlestore/results/c6a.4xlarge.json
+++ b/singlestore/results/c6a.4xlarge.json
@@ -7,7 +7,7 @@
     "tuned": "yes",
     "comment": "Previous name: MemSQL. Some queries did not run due to memory limits",
 
-    "tags": ["MySQL compatible", "column-oriented"],
+    "tags": ["MySQL compatible", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 690,
     "data_size": 29836263469,

--- a/singlestore/template.json
+++ b/singlestore/template.json
@@ -4,6 +4,7 @@
   "tuned": "yes",
   "tags": [
     "MySQL compatible",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/spark-auron/results/c6a.2xlarge.json
+++ b/spark-auron/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/results/c6a.4xlarge.json
+++ b/spark-auron/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/results/c6a.large.json
+++ b/spark-auron/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/results/c6a.metal.json
+++ b/spark-auron/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/results/c6a.xlarge.json
+++ b/spark-auron/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/results/c7a.metal-48xl.json
+++ b/spark-auron/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Java","Rust","column-oriented","Spark derivative"],
+    "tags": ["Java","Rust","column-oriented","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-auron/template.json
+++ b/spark-auron/template.json
@@ -6,6 +6,7 @@
       "Java",
       "Rust",
       "column-oriented",
-      "Spark derivative"
+      "Spark derivative",
+      "lukewarm-cold-run"
     ]
 }

--- a/spark-comet/results/c6a.2xlarge.json
+++ b/spark-comet/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c6a.4xlarge.json
+++ b/spark-comet/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c6a.metal.json
+++ b/spark-comet/results/c6a.metal.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c6a.xlarge.json
+++ b/spark-comet/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c7a.metal-48xl.json
+++ b/spark-comet/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":  ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c8g.4xlarge.json
+++ b/spark-comet/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/results/c8g.metal-48xl.json
+++ b/spark-comet/results/c8g.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative"],
+    "tags":   ["Java", "Rust", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-comet/template.json
+++ b/spark-comet/template.json
@@ -6,6 +6,7 @@
     "Java",
     "Rust",
     "column-oriented",
-    "Spark derivative"
+    "Spark derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/spark-gluten/results/c6a.4xlarge.json
+++ b/spark-gluten/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "Using Gluten 1.4.0 with Spark 3.5.2",
-    "tags": ["Java", "C++", "column-oriented", "Spark derivative"],
+    "tags": ["Java", "C++", "column-oriented", "Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark-gluten/template.json
+++ b/spark-gluten/template.json
@@ -6,6 +6,7 @@
     "Java",
     "C++",
     "column-oriented",
-    "Spark derivative"
+    "Spark derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/spark/results/c6a.2xlarge.json
+++ b/spark/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented","stateless","Spark derivative"],
+    "tags":   ["Java","column-oriented","stateless","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark/results/c6a.4xlarge.json
+++ b/spark/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Java","column-oriented","stateless","Spark derivative"],
+    "tags":  ["Java","column-oriented","stateless","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark/results/c6a.xlarge.json
+++ b/spark/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented","stateless","Spark derivative"],
+    "tags":   ["Java","column-oriented","stateless","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark/results/c8g.4xlarge.json
+++ b/spark/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Java","column-oriented","stateless","Spark derivative"],
+    "tags":   ["Java","column-oriented","stateless","Spark derivative", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/spark/template.json
+++ b/spark/template.json
@@ -6,6 +6,7 @@
     "Java",
     "column-oriented",
     "stateless",
-    "Spark derivative"
+    "Spark derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/sqlite/results/c6a.2xlarge.json
+++ b/sqlite/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","embedded","row-oriented"],
+    "tags":   ["C","embedded","row-oriented", "lukewarm-cold-run"],
     "load_time": 3189,
     "data_size": 75776589824,
     "result": [

--- a/sqlite/results/c6a.4xlarge.json
+++ b/sqlite/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C","embedded","row-oriented"],
+    "tags":  ["C","embedded","row-oriented", "lukewarm-cold-run"],
     "load_time": 2674,
     "data_size": 75776589824,
     "result": [

--- a/sqlite/results/c6a.large.json
+++ b/sqlite/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","embedded","row-oriented"],
+    "tags":   ["C","embedded","row-oriented", "lukewarm-cold-run"],
     "load_time": 3539,
     "data_size": 75776589824,
     "result": [

--- a/sqlite/results/c6a.xlarge.json
+++ b/sqlite/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","embedded","row-oriented"],
+    "tags":   ["C","embedded","row-oriented", "lukewarm-cold-run"],
     "load_time": 3496,
     "data_size": 75776589824,
     "result": [

--- a/sqlite/template.json
+++ b/sqlite/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C",
     "embedded",
-    "row-oriented"
+    "row-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/starrocks/results/c6a.2xlarge.json
+++ b/starrocks/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible"],
+    "tags": ["C++","column-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 408,
     "data_size": 16335244812,
     "result": [

--- a/starrocks/results/c6a.4xlarge.json
+++ b/starrocks/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible"],
+    "tags": ["C++","column-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 396,
     "data_size": 16336055981,
     "result": [

--- a/starrocks/results/c6a.metal.json
+++ b/starrocks/results/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "",
-    "tags": ["C++", "column-oriented", "MySQL compatible"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "lukewarm-cold-run"],
     "load_time": 341,
     "data_size": 16334421700,
     "result": [

--- a/starrocks/results/c6a.xlarge.json
+++ b/starrocks/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++","column-oriented","MySQL compatible"],
+    "tags": ["C++","column-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 477,
     "data_size": 16342759970,
     "result": [

--- a/starrocks/results/c7a.metal-48xl.json
+++ b/starrocks/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","MySQL compatible"],
+    "tags":  ["C++","column-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 386,
     "data_size": 16343224445,
     "result": [

--- a/starrocks/results/c8g.4xlarge.json
+++ b/starrocks/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","MySQL compatible"],
+    "tags":   ["C++","column-oriented","MySQL compatible", "lukewarm-cold-run"],
     "load_time": 444,
     "data_size": 16315612566,
     "result": [

--- a/starrocks/template.json
+++ b/starrocks/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "MySQL compatible"
+    "MySQL compatible",
+    "lukewarm-cold-run"
   ]
 }

--- a/supabase/results/supabase.json
+++ b/supabase/results/supabase.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["C", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
 
     "load_time": 1350,
     "data_size": 106489682778,

--- a/tembo-olap/results/tembo-olap-col-c6a.json
+++ b/tembo-olap/results/tembo-olap-col-c6a.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "PostgreSQL compatible", "column-oriented"],
+    "tags": ["C", "PostgreSQL compatible", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 4903,
     "data_size": 33864704000,

--- a/tidb/results/c6a.4xlarge-tiflash-only.json
+++ b/tidb/results/c6a.4xlarge-tiflash-only.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "tuned": "no",
     "comment": "v8.5.1",
-    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative"],
+    "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 4448,
     "data_size": 147868755269,
     "result": [

--- a/tidb/results/c6a.4xlarge-tikv-only.json
+++ b/tidb/results/c6a.4xlarge-tikv-only.json
@@ -6,7 +6,7 @@
     "comment": "v8.5.1",
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["Rust", "row-oriented", "MySQL compatible"],
+    "tags": ["Rust", "row-oriented", "MySQL compatible", "lukewarm-cold-run"],
     "load_time": 4069,
     "data_size": 61598458152,
     "result": [

--- a/tidb/results/c6a.metal-tiflash.json
+++ b/tidb/results/c6a.metal-tiflash.json
@@ -6,7 +6,7 @@
   "proprietary": "no",
   "tuned": "no",
   "comment": "v8.5.1",
-  "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative"],
+  "tags": ["C++", "column-oriented", "MySQL compatible", "ClickHouse derivative", "lukewarm-cold-run"],
   "load_time": 3473.056,
   "data_size": 147974939737,
   "result": [

--- a/tidb/template.json
+++ b/tidb/template.json
@@ -6,6 +6,7 @@
     "C++",
     "column-oriented",
     "MySQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/timescaledb-no-columnstore/results/c6a.4xlarge.json
+++ b/timescaledb-no-columnstore/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
   "proprietary": "no",
   "tuned": "no",
   "comment": "",
-  "tags": ["C", "PostgreSQL compatible", "row-oriented", "time-series"],
+  "tags": ["C", "PostgreSQL compatible", "row-oriented", "time-series", "lukewarm-cold-run"],
   "load_time": 2633,
   "data_size": 72021778432,
   "result": [

--- a/timescaledb-no-columnstore/results/c8g.4xlarge.json
+++ b/timescaledb-no-columnstore/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C", "PostgreSQL compatible", "row-oriented", "time-series"],
+    "tags":  ["C", "PostgreSQL compatible", "row-oriented", "time-series", "lukewarm-cold-run"],
     "load_time": 2477,
     "data_size": 72021778432,
     "result": [

--- a/timescaledb-no-columnstore/template.json
+++ b/timescaledb-no-columnstore/template.json
@@ -6,6 +6,7 @@
     "C",
     "PostgreSQL compatible",
     "row-oriented",
-    "time-series"
+    "time-series",
+    "lukewarm-cold-run"
   ]
 }

--- a/timescaledb/results/c6a.4xlarge.json
+++ b/timescaledb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["C","PostgreSQL compatible","column-oriented","time-series"],
+    "tags":  ["C","PostgreSQL compatible","column-oriented","time-series", "lukewarm-cold-run"],
     "load_time": 1265,
     "data_size": 19304833024,
     "result": [

--- a/timescaledb/results/c8g.4xlarge.json
+++ b/timescaledb/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["C","PostgreSQL compatible","column-oriented","time-series"],
+    "tags":   ["C","PostgreSQL compatible","column-oriented","time-series", "lukewarm-cold-run"],
     "load_time": 1194,
     "data_size": 19304833024,
     "result": [

--- a/timescaledb/template.json
+++ b/timescaledb/template.json
@@ -6,6 +6,7 @@
     "C",
     "PostgreSQL compatible",
     "column-oriented",
-    "time-series"
+    "time-series",
+    "lukewarm-cold-run"
   ]
 }

--- a/ursa/results/c6a.2xlarge.json
+++ b/ursa/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 277,
     "data_size": 15451849156,
     "result": [

--- a/ursa/results/c6a.4xlarge.json
+++ b/ursa/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 211,
     "data_size": 15442611709,
     "result": [

--- a/ursa/results/c6a.large.json
+++ b/ursa/results/c6a.large.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 479,
     "data_size": 15506384415,
     "result": [

--- a/ursa/results/c6a.metal.json
+++ b/ursa/results/c6a.metal.json
@@ -6,7 +6,7 @@
   "proprietary": "yes",
   "tuned": "no",
   "comment": "",
-  "tags": ["C++", "column-oriented", "ClickHouse derivative"],
+  "tags": ["C++", "column-oriented", "ClickHouse derivative", "lukewarm-cold-run"],
   "load_time": 153.331,
   "data_size": 15565240886,
   "result": [

--- a/ursa/results/c6a.xlarge.json
+++ b/ursa/results/c6a.xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "yes",
     "tuned":   "no",
-    "tags":   ["C++","column-oriented","ClickHouse derivative"],
+    "tags":   ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 322,
     "data_size": 15476043873,
     "result": [

--- a/ursa/results/c7a.metal-48xl.json
+++ b/ursa/results/c7a.metal-48xl.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "yes",
     "tuned":  "no",
-    "tags":  ["C++","column-oriented","ClickHouse derivative"],
+    "tags":  ["C++","column-oriented","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 7,
     "data_size": 15467764900,
     "result": [

--- a/ursa/template.json
+++ b/ursa/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "column-oriented",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/victorialogs/results/c6a.2xlarge.json
+++ b/victorialogs/results/c6a.2xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","column-oriented"],
+    "tags":   ["Go","column-oriented", "lukewarm-cold-run"],
     "load_time": 5137,
     "data_size": 16939219271,
     "result": [

--- a/victorialogs/results/c6a.4xlarge.json
+++ b/victorialogs/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":  "no",
     "tuned":  "no",
-    "tags":  ["Go","column-oriented"],
+    "tags":  ["Go","column-oriented", "lukewarm-cold-run"],
     "load_time": 1050,
     "data_size": 16972898296,
     "result": [

--- a/victorialogs/results/c8g.4xlarge.json
+++ b/victorialogs/results/c8g.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary":   "no",
     "tuned":   "no",
-    "tags":   ["Go","column-oriented"],
+    "tags":   ["Go","column-oriented", "lukewarm-cold-run"],
     "load_time": 1055,
     "data_size": 16968171014,
     "result": [

--- a/victorialogs/template.json
+++ b/victorialogs/template.json
@@ -4,6 +4,7 @@
   "tuned": "no",
   "tags": [
     "Go",
-    "column-oriented"
+    "column-oriented",
+    "lukewarm-cold-run"
   ]
 }

--- a/ydb/results/64vCPU.3nodes.json
+++ b/ydb/results/64vCPU.3nodes.json
@@ -7,7 +7,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["column-oriented", "C++", "ClickHouse derivative"],
+    "tags": ["column-oriented", "C++", "ClickHouse derivative", "lukewarm-cold-run"],
 
     "load_time": 978,
     "data_size": 27473988280,

--- a/yugabytedb/results/c6a.4xlarge.json
+++ b/yugabytedb/results/c6a.4xlarge.json
@@ -5,7 +5,7 @@
     "cluster_size": 1,
     "proprietary": "no",
     "tuned": "no",
-    "tags": ["C++", "row-oriented", "PostgreSQL compatible"],
+    "tags": ["C++", "row-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
     "load_time": 4683,
     "data_size": 76883037634,
     "result": [

--- a/yugabytedb/template.json
+++ b/yugabytedb/template.json
@@ -5,6 +5,7 @@
   "tags": [
     "C++",
     "row-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "lukewarm-cold-run"
   ]
 }


### PR DESCRIPTION
This PR addresses https://github.com/ClickHouse/ClickBench/issues/667. It introduces a distinction between lukewarm runs and cold runs. The former is considered legacy and README.md now encourages to migrate to the latter.

For the time being, all existing submissions were labeled `lukewarm-cold-runs` except
- DBaaS entries (Redshift, BigQuery, etc.),
- the databases touched by https://github.com/ClickHouse/ClickBench/pull/659 (Umbra, Hyper, CedarDB) - these have proper cold runs already.
- all entries below "versions/" and "hardware/" (they are unrelated to the official ClickBench benchmark).

We encourage PRs that migrate submissions from lukewarm to cold runs.
(We'll adjust all ClickHouse-related entries by ourselves soon).