### PR TITLE
Use Polars streaming

### DIFF
--- a/polars-dataframe/query.py
+++ b/polars-dataframe/query.py
@@ -6,6 +6,8 @@ from datetime import date
 import json
 import os
 
+# The streaming engine will be the default soon
+# https://pola.rs/posts/polars-in-aggregate-dec25/
 pl.Config.set_engine_affinity("streaming")
 
 # 0: No., 1: SQL, 2: Polars

--- a/polars/query.py
+++ b/polars/query.py
@@ -6,6 +6,8 @@ from datetime import date
 import json
 import os
 
+# The streaming engine will be the default soon
+# https://pola.rs/posts/polars-in-aggregate-dec25/
 pl.Config.set_engine_affinity("streaming")
 
 # 0: No., 1: SQL, 2: Polars


### PR DESCRIPTION
Hi, I am from the Polars team, and for benchmarking purposes we always recommend to run on the streaming engine. It is much faster than the in-memory engine for almost all queries. 
