### PR TITLE
Don't print query no. in Polars benchmarks

### DIFF
--- a/polars-dataframe/query.py
+++ b/polars-dataframe/query.py
@@ -476,7 +476,8 @@ def run_timings(lf: pl.LazyFrame) -> None:
                 times.append(None)
             else:
                 times.append(round(end - start, 3))
-        print(times)
+        print(f"{times},")
+
 
 data_size = os.path.getsize("hits.parquet")
 

--- a/polars/query.py
+++ b/polars/query.py
@@ -476,7 +476,7 @@ def run_timings(lf: pl.LazyFrame) -> None:
                 times.append(None)
             else:
                 times.append(round(end - start, 3))
-        print(times)
+        print(f"{times},")
 
 
 data_size = os.path.getsize("hits.parquet")


### PR DESCRIPTION
As requested in #736 