### PR TITLE
GizmoSQL: remove unusual tags

### DIFF
--- a/gizmosql/results/c6a.4xlarge.json
+++ b/gizmosql/results/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","arrow-flight-sql","duckdb-backend","cold-run","tls-disabled"],
+    "tags": ["C++","column-oriented"],
     "load_time": 131.966,
     "data_size": 26924298240,
     "result": [

--- a/gizmosql/template.json
+++ b/gizmosql/template.json
@@ -5,10 +5,6 @@
   "tuned": "no",
   "tags": [
     "C++",
-    "column-oriented",
-    "arrow-flight-sql",
-    "duckdb-backend",
-    "cold-run",
-    "tls-disabled"
+    "column-oriented"
   ]
 }


### PR DESCRIPTION
These tags are not used in any other submissions and therefore not very useful.