### PR TITLE
Show only CPU databases by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@ let selectors = {
     "machine": {},
     "cluster_size": {},
     "opensource": {"yes": true, "no": true},
-    "hardware": {"cpu": true, "gpu": true},
+    "hardware": {"cpu": true, "gpu": false},
     "tuned": {"no": true, "yes": false},
     "metric": "combined",
     "queries": [],


### PR DESCRIPTION
Allows to compare submissions with the default settings on a more fair basis