### PR TITLE
fix(datafusion): keep hot runs in one session

### DIFF
--- a/datafusion-partitioned/run.sh
+++ b/datafusion-partitioned/run.sh
@@ -2,35 +2,45 @@
 
 TRIES=3
 QUERY_NUM=1
-SETUP_STATEMENTS=$(grep -o ';' create.sql | wc -l | tr -d '[:space:]')
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 echo $1
-while IFS= read -r query || [ -n "$query" ]; do
+while read -r query; do
     [ -z "$query" ] && continue
 
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
 
     QUERY_FILE="${TMP_DIR}/query-${QUERY_NUM}.sql"
-    cp create.sql "${QUERY_FILE}"
-    printf '\n' >> "${QUERY_FILE}"
+    MARKER="clickbench_query_${QUERY_NUM}_start"
+    printf "SELECT '${MARKER}';\n\n" > "${QUERY_FILE}"
     for i in $(seq 1 $TRIES); do
         printf '%s\n\n' "$query" >> "${QUERY_FILE}"
     done
 
-    ALL_ELAPSED_VALUES=()
-    while IFS= read -r res; do
-        ALL_ELAPSED_VALUES[${#ALL_ELAPSED_VALUES[@]}]="$res"
-    done < <(
-        datafusion-cli -f "${QUERY_FILE}" 2>&1 |
-        awk '/Elapsed/ { print $2 }'
-    )
+    # Keep all tries in one process so DataFusion process-local caches stay hot.
+    # Use a marker query to ignore setup timings from create.sql.
+    ELAPSED_FILE="${TMP_DIR}/elapsed-${QUERY_NUM}.txt"
+    OUTPUT_FILE="${TMP_DIR}/output-${QUERY_NUM}.txt"
+    datafusion-cli -f create.sql "${QUERY_FILE}" > "${OUTPUT_FILE}" 2>&1
+    awk -v marker="$MARKER" '
+        index($0, marker) { seen = 1 }
+        seen && /Elapsed/ {
+            if (!skipped_marker_elapsed) {
+                skipped_marker_elapsed = 1
+                next
+            }
+            print $2
+        }
+    ' "${OUTPUT_FILE}" > "${ELAPSED_FILE}"
+    if [ "$(wc -l < "${ELAPSED_FILE}")" -lt "$TRIES" ]; then
+        grep -v "Elapsed" "${OUTPUT_FILE}" >&2
+    fi
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        RES="${ALL_ELAPSED_VALUES[$((SETUP_STATEMENTS + i - 1))]}"
+        RES=$(awk -v line="$i" 'NR == line { print; exit }' "${ELAPSED_FILE}")
         [[ $RES != "" ]] && \
             echo -n "$RES" || \
             echo -n "null"

--- a/datafusion-partitioned/run.sh
+++ b/datafusion-partitioned/run.sh
@@ -2,20 +2,35 @@
 
 TRIES=3
 QUERY_NUM=1
+SETUP_STATEMENTS=$(grep -o ';' create.sql | wc -l | tr -d '[:space:]')
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
 echo $1
-cat queries.sql | while read -r query; do
+while IFS= read -r query || [ -n "$query" ]; do
+    [ -z "$query" ] && continue
+
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
 
-    echo "$query" > /tmp/query.sql
+    QUERY_FILE="${TMP_DIR}/query-${QUERY_NUM}.sql"
+    cp create.sql "${QUERY_FILE}"
+    printf '\n' >> "${QUERY_FILE}"
+    for i in $(seq 1 $TRIES); do
+        printf '%s\n\n' "$query" >> "${QUERY_FILE}"
+    done
+
+    ALL_ELAPSED_VALUES=()
+    while IFS= read -r res; do
+        ALL_ELAPSED_VALUES[${#ALL_ELAPSED_VALUES[@]}]="$res"
+    done < <(
+        datafusion-cli -f "${QUERY_FILE}" 2>&1 |
+        awk '/Elapsed/ { print $2 }'
+    )
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        # 1. there will be two query result, one for creating table another for executing the select statement
-        # 2. each query contains a "Query took xxx seconds", we just grep these 2 lines
-        # 3. use sed to take the second line
-        # 4. use awk to take the number we want
-        RES=$(datafusion-cli -f create.sql /tmp/query.sql 2>&1 | grep "Elapsed" |tail -1| awk '{ print $2 }')
+        RES="${ALL_ELAPSED_VALUES[$((SETUP_STATEMENTS + i - 1))]}"
         [[ $RES != "" ]] && \
             echo -n "$RES" || \
             echo -n "null"
@@ -25,4 +40,4 @@ cat queries.sql | while read -r query; do
     echo "],"
 
     QUERY_NUM=$((QUERY_NUM + 1))
-done
+done < queries.sql

--- a/datafusion/run.sh
+++ b/datafusion/run.sh
@@ -2,20 +2,45 @@
 
 TRIES=3
 QUERY_NUM=1
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
 echo $1
-cat queries.sql | while read -r query; do
+while read -r query; do
+    [ -z "$query" ] && continue
+
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
 
-    echo "$query" > /tmp/query.sql
+    QUERY_FILE="${TMP_DIR}/query-${QUERY_NUM}.sql"
+    MARKER="clickbench_query_${QUERY_NUM}_start"
+    printf "SELECT '${MARKER}';\n\n" > "${QUERY_FILE}"
+    for i in $(seq 1 $TRIES); do
+        printf '%s\n\n' "$query" >> "${QUERY_FILE}"
+    done
+
+    # Keep all tries in one process so DataFusion process-local caches stay hot.
+    # Use a marker query to ignore setup timings from create.sql.
+    ELAPSED_FILE="${TMP_DIR}/elapsed-${QUERY_NUM}.txt"
+    OUTPUT_FILE="${TMP_DIR}/output-${QUERY_NUM}.txt"
+    datafusion-cli -f create.sql "${QUERY_FILE}" > "${OUTPUT_FILE}" 2>&1
+    awk -v marker="$MARKER" '
+        index($0, marker) { seen = 1 }
+        seen && /Elapsed/ {
+            if (!skipped_marker_elapsed) {
+                skipped_marker_elapsed = 1
+                next
+            }
+            print $2
+        }
+    ' "${OUTPUT_FILE}" > "${ELAPSED_FILE}"
+    if [ "$(wc -l < "${ELAPSED_FILE}")" -lt "$TRIES" ]; then
+        grep -v "Elapsed" "${OUTPUT_FILE}" >&2
+    fi
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        # 1. there will be two query result, one for creating table another for executing the select statement
-        # 2. each query contains a "Query took xxx seconds", we just grep these 2 lines
-        # 3. use sed to take the second line
-        # 4. use awk to take the number we want
-        RES=$(datafusion-cli -f create.sql /tmp/query.sql 2>&1 | grep "Elapsed" |tail -1 | awk '{ print $2 }')
+        RES=$(awk -v line="$i" 'NR == line { print; exit }' "${ELAPSED_FILE}")
         [[ $RES != "" ]] && \
             echo -n "$RES" || \
             echo -n "null"
@@ -25,4 +50,4 @@ cat queries.sql | while read -r query; do
     echo "],"
 
     QUERY_NUM=$((QUERY_NUM + 1))
-done
+done < queries.sql


### PR DESCRIPTION
## Summary

This fixes the partitioned DataFusion runner so hot runs are really hot. See https://github.com/apache/datafusion/issues/21696

Before this change, the script started a new `datafusion-cli` process for every try. That made each try use a cold process, so tries 2 and 3 did not keep the warmed metadata cache.

## What changed

  - drop OS cache once before each query
  - build one SQL file with `create.sql` and the same query 3 times
  - run that file in one `datafusion-cli` session
  - skip the setup `Elapsed` lines from `create.sql`
  - keep failed later tries as `null` instead of mixing in setup timings

  This follows the same main idea used by the DuckDB partitioned runner: one process per query, with repeated runs inside that process.

Thank you for review 🙏

**Thank You for Your Contribution!**

We appreciate your effort and contribution to the project. To ensure that your Pull Request (PR) adheres to our guidelines, please ensure to review the rules mentioned in our contribution guidelines:

[ClickHouse/ClickBench Contribution Rules](https://github.com/ClickHouse/ClickBench#rules-and-contribution)

Thank you for your attention to these details and for helping us maintain the quality and integrity of the project.

