### PR TITLE
Fix Hot Run tab crash when a result file has fewer queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,6 +710,7 @@ const combined_cold_share = 0.2;
 const combined_hot_share = 0.6;
 
 function selectRun(timings, metric) {
+    if (timings == null) return null;
     const cold_timing = timings[0];
     const hot_timing = (timings[1] !== null && timings[2] !== null ? Math.min(timings[1], timings[2]) : null);
 
@@ -777,7 +778,7 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num][run_num]).filter(x => x != null))));
+            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num]?.[run_num]).filter(x => x != null))));
 
     const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x && x > 5));
     const min_data_size = Math.min(...filtered_data.map(elem => elem.data_size).filter(x => x && x > 1e9));


### PR DESCRIPTION
## Summary
- Switching to the **Hot Run** tab crashed with `Uncaught TypeError: Cannot read properties of undefined (reading '0')` at `index.html:780`.
- Root cause: `pandas/results/c6a.metal.json` has only 42 query entries (missing the 43rd). Hot Run is the only metric that does not filter out `in-memory`-tagged systems, so pandas was the only entry that exercised the missing-query path.
- Made the renderer robust to short result arrays:
  - `selectRun` returns `null` when given a missing/undefined timings entry.
  - Baseline computation uses optional chaining when reading `elem.result[query_num]?.[run_num]`.

## Test plan
- [ ] Open `index.html` and switch between Cold Run / Hot Run / Combined / Load tabs — no console errors.
- [ ] Hot Run tab renders with pandas included; the missing 43rd query falls back via the existing `fallback_timing` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)