### PR TITLE
Set up `earlyoom` in the automated runner to prevent DuckDB from hanging on small VMs.

### DIFF
--- a/cloud-init.sh.in
+++ b/cloud-init.sh.in
@@ -4,7 +4,9 @@
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y wget curl git jq
+apt-get install -y wget curl git jq earlyoom
+
+systemctl enable --now earlyoom
 
 git clone --depth 1 'https://github.com/@repo@.git' --branch '@branch@' ClickBench
 cd ClickBench/@system@


### PR DESCRIPTION
## Summary
- Install `earlyoom` and enable it via systemd in `cloud-init.sh.in` so benchmark VMs handle memory pressure by killing the heaviest process early instead of stalling on a kernel OOM.

## Test plan
- [ ] Run `./run-benchmark.sh` against a small instance and confirm `systemctl status earlyoom` is active before `benchmark.sh` starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)