### PR TITLE
Fix Databend run.sh to report null on query failure

### DIFF
--- a/databend/run.sh
+++ b/databend/run.sh
@@ -8,13 +8,20 @@ cat queries.sql | while read -r query; do
 
     echo -n "["
     for i in $(seq 1 $TRIES); do
-        RES=$(curl -w 'Time: %{time_total}\n' "http://default@localhost:8124" -d "${query}" 2>&1 | grep -P '^Time: ' | sed 's/Time: //')
-        if [[ "$?" == "0" && -n "${RES}" ]]
+        BODY=$(mktemp)
+        STATS=$(curl -sS -o "$BODY" -w 'HTTP:%{http_code} TIME:%{time_total}\n' "http://default@localhost:8124" -d "${query}" 2>&1)
+        CURL_EXIT=$?
+        HTTP_CODE=$(echo "$STATS" | grep -oP 'HTTP:\K[0-9]+')
+        RES=$(echo "$STATS" | grep -oP 'TIME:\K[0-9.]+')
+
+        if [[ "$CURL_EXIT" == "0" && "$HTTP_CODE" == "200" && -n "${RES}" ]] && ! grep -qiE '"error"|exception|error code' "$BODY"
         then
             echo -n "${RES}"
         else
             echo -n "null"
+            RES=""
         fi
+        rm -f "$BODY"
         [[ "$i" != $TRIES ]] && echo -n ", "
 
         echo "${QUERY_NUM},${i},${RES}" >> result.csv


### PR DESCRIPTION
Databend fails intermittently on small machines, but the script mistakenly reports zero.

## Summary
- The old pipeline `curl | grep | sed` checked `$?`, which reflects only sed's exit status. Whenever Databend returned an error response that still contained `Time: %{time_total}` from curl's `-w`, grep matched it and the script logged it as a successful timing.
- This is why benchmarks on small instances (e.g. t3a.small) were filled with `0` / `0.001` values where the queries had actually failed instantly.
- Now we capture HTTP status and the response body separately. A trial is only counted as successful when curl exits 0, HTTP code is 200, and the body contains no `"error"` / `exception` / `error code` markers; otherwise the trial reports `null`.

## Test plan
- [ ] Run `./run.sh` against a healthy Databend instance — successful queries still produce numeric timings.
- [ ] Run against an instance where some queries OOM/fail — those trials report `null` (not `0`).
- [ ] Verify `result.csv` no longer logs a timing for failed trials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)