### PR TITLE
Add shared download scripts for hits dataset

### DIFF
--- a/cedardb/benchmark.sh
+++ b/cedardb/benchmark.sh
@@ -5,11 +5,7 @@ sudo apt-get update -y
 sudo apt-get install -y docker.io postgresql-client gzip
 
 # download dataset
-echo "Downloading dataset..."
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-echo "Unpacking dataset..."
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 mkdir data
 mv hits.tsv data
 chmod -R 777 data

--- a/chdb-dataframe/benchmark.sh
+++ b/chdb-dataframe/benchmark.sh
@@ -10,7 +10,7 @@ pip install pandas pyarrow
 pip install chdb
 
 # Download the data
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/chdb-parquet-partitioned/benchmark.sh
+++ b/chdb-parquet-partitioned/benchmark.sh
@@ -10,7 +10,7 @@ pip install psutil pyarrow
 pip install chdb
 
 # Load the data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 # Run the queries
 

--- a/chdb/benchmark.sh
+++ b/chdb/benchmark.sh
@@ -9,9 +9,7 @@ pip install psutil pyarrow
 pip install chdb
 
 # Load the data
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 
 echo -n "Load time: "
 command time -f '%e' ./load.py

--- a/citus/benchmark.sh
+++ b/citus/benchmark.sh
@@ -7,9 +7,7 @@ sudo apt-get install -y postgresql-client
 export PGPASSWORD=mypass
 sudo docker run -d --name citus -p 5432:5432 -e POSTGRES_PASSWORD=$PGPASSWORD citusdata/citus:11.0
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 echo "*:*:*:*:mypass" > .pgpass
 chmod 400 .pgpass

--- a/clickhouse-parquet-partitioned/benchmark.sh
+++ b/clickhouse-parquet-partitioned/benchmark.sh
@@ -4,7 +4,7 @@
 
 curl https://clickhouse.com/ | sh
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 # Run the queries
 

--- a/clickhouse-parquet/benchmark.sh
+++ b/clickhouse-parquet/benchmark.sh
@@ -4,7 +4,7 @@
 
 curl https://clickhouse.com/ | sh
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/clickhouse-tencent/benchmark.sh
+++ b/clickhouse-tencent/benchmark.sh
@@ -17,7 +17,7 @@ done
 
 clickhouse-client < create.sql
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 sudo mv hits_*.parquet /var/lib/clickhouse/user_files/
 sudo chown clickhouse:clickhouse /var/lib/clickhouse/user_files/hits_*.parquet
 

--- a/clickhouse/benchmark.sh
+++ b/clickhouse/benchmark.sh
@@ -37,7 +37,7 @@ fi
 
 clickhouse-client < create"$SUFFIX".sql
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 sudo mv hits_*.parquet /var/lib/clickhouse/user_files/
 sudo chown clickhouse:clickhouse /var/lib/clickhouse/user_files/hits_*.parquet
 

--- a/daft-parquet-partitioned/benchmark.sh
+++ b/daft-parquet-partitioned/benchmark.sh
@@ -9,7 +9,7 @@ pip install pandas
 pip install packaging
 pip install daft==0.7.4
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 mode=partitioned
 echo "Running $mode mode..."

--- a/daft-parquet/benchmark.sh
+++ b/daft-parquet/benchmark.sh
@@ -9,7 +9,7 @@ pip install pandas
 pip install packaging
 pip install daft
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet'
+../download-hits-parquet-single
 
 # Run the queries
 mode=single

--- a/databend/benchmark.sh
+++ b/databend/benchmark.sh
@@ -30,9 +30,7 @@ do
   sleep 1
 done
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 ## Aws gp2 write performance is not stable, we must load the data when disk's write around ~500MB/s (Don't know much about the rules of gp2)
 # Load Data

--- a/datafusion-partitioned/benchmark.sh
+++ b/datafusion-partitioned/benchmark.sh
@@ -36,8 +36,7 @@ export PATH="`pwd`/target/release:$PATH"
 cd ..
 
 echo "Download benchmark target data, partitioned"
-mkdir -p partitioned
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix partitioned --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned partitioned
 
 echo "Run benchmarks for partitioned"
 ./run.sh

--- a/datafusion/benchmark.sh
+++ b/datafusion/benchmark.sh
@@ -37,7 +37,7 @@ export PATH="`pwd`/target/release:$PATH"
 cd ..
 
 echo "Download benchmark target data, single file"
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/hits.parquet
+../download-hits-parquet-single
 
 echo "Run benchmarks"
 ./run.sh

--- a/doris-parquet/benchmark.sh
+++ b/doris-parquet/benchmark.sh
@@ -77,9 +77,7 @@ do
 done
 
 # Download Parquet files
-cd "$DORIS_HOME/be"
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
-cd -
+../download-hits-parquet-partitioned "$DORIS_HOME/be"
 
 # Run the queries
 mysql -h127.1 -P9030 -uroot -vvv < create.sql

--- a/doris/benchmark.sh
+++ b/doris/benchmark.sh
@@ -96,10 +96,8 @@ mysql -h 127.0.0.1 -P9030 -uroot hits <"$ROOT"/create.sql
 
 # Download data
 BE_DATA_DIR="$DORIS_HOME/be/"
-mkdir -p "$BE_DATA_DIR/user_files_secure"
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
-mv *.parquet "$BE_DATA_DIR/user_files_secure" 
+"$ROOT"/../download-hits-parquet-partitioned "$BE_DATA_DIR/user_files_secure"
 
 BE_ID=$(mysql -h127.0.0.1 -P9030 -uroot -N -e 'show backends' | awk '{print $1}' | head -1)
 

--- a/download-hits-csv
+++ b/download-hits-csv
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Usage: download-hits-csv [destination-dir]
+# Downloads hits.csv.gz and decompresses it. Files end up in the current
+# directory unless a destination directory is given as the first argument.
+set -e
+
+dir="${1:-.}"
+mkdir -p "$dir"
+cd "$dir"
+
+sudo apt-get install -y pigz
+wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+pigz -d -f hits.csv.gz

--- a/download-hits-parquet-partitioned
+++ b/download-hits-parquet-partitioned
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Usage: download-hits-parquet-partitioned [destination-dir]
+# Downloads hits_0.parquet … hits_99.parquet. Files end up in the current
+# directory unless a destination directory is given as the first argument.
+set -e
+
+dir="${1:-.}"
+mkdir -p "$dir"
+cd "$dir"
+
+seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'

--- a/download-hits-parquet-single
+++ b/download-hits-parquet-single
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Usage: download-hits-parquet-single [destination-dir]
+# Downloads hits.parquet (Athena-compatible variant). Files end up in the
+# current directory unless a destination directory is given as the first
+# argument.
+set -e
+
+dir="${1:-.}"
+mkdir -p "$dir"
+cd "$dir"
+
+wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet'

--- a/download-hits-tsv
+++ b/download-hits-tsv
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Usage: download-hits-tsv [destination-dir]
+# Downloads hits.tsv.gz and decompresses it. Files end up in the current
+# directory unless a destination directory is given as the first argument.
+set -e
+
+dir="${1:-.}"
+mkdir -p "$dir"
+cd "$dir"
+
+sudo apt-get install -y pigz
+wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
+pigz -d -f hits.tsv.gz

--- a/drill/benchmark.sh
+++ b/drill/benchmark.sh
@@ -3,7 +3,7 @@
 sudo apt-get update -y
 sudo apt-get install -y docker.io
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 ./run.sh 2>&1 | tee log.txt
 

--- a/druid/benchmark.sh
+++ b/druid/benchmark.sh
@@ -26,9 +26,7 @@ echo "druid.query.groupBy.maxMergingDictionarySize=5000000000" >> apache-druid-$
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 echo -n "Load time: "
 command time -f '%e' ./apache-druid-${VERSION}/bin/post-index-task --file ingest.json --url http://localhost:8081

--- a/duckdb-dataframe/benchmark.sh
+++ b/duckdb-dataframe/benchmark.sh
@@ -9,7 +9,7 @@ source myenv/bin/activate
 pip install pandas duckdb pyarrow
 
 # Download the data
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/duckdb-memory/benchmark.sh
+++ b/duckdb-memory/benchmark.sh
@@ -9,7 +9,7 @@ source myenv/bin/activate
 pip install duckdb psutil
 
 # Load the data
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/duckdb-parquet-partitioned/benchmark.sh
+++ b/duckdb-parquet-partitioned/benchmark.sh
@@ -6,7 +6,7 @@ curl https://install.duckdb.org | sh
 export PATH=$HOME'/.duckdb/cli/latest':$PATH
 
 # Load the data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 echo -n "Load time: "
 command time -f '%e' duckdb hits.db -f create.sql

--- a/duckdb-parquet/benchmark.sh
+++ b/duckdb-parquet/benchmark.sh
@@ -6,7 +6,7 @@ curl https://install.duckdb.org | sh
 export PATH=$HOME'/.duckdb/cli/latest':$PATH
 
 # Load the data
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 echo -n "Load time: "
 command time -f '%e' duckdb hits.db -f create.sql

--- a/duckdb-vortex-partitioned/benchmark.sh
+++ b/duckdb-vortex-partitioned/benchmark.sh
@@ -18,7 +18,7 @@ export PATH="`pwd`/build/release/:$PATH"
 cd ..
 
 # Load the data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 # Convert parquet files to vortex partitioned
 echo -n "Load time: "

--- a/duckdb-vortex/benchmark.sh
+++ b/duckdb-vortex/benchmark.sh
@@ -10,7 +10,7 @@ export PATH=$HOME'/.duckdb/cli/latest':$PATH
 duckdb -c "INSTALL vortex;"
 
 # Load the data
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Convert parquet files to Vortex
 echo -n "Load time: "

--- a/duckdb/benchmark.sh
+++ b/duckdb/benchmark.sh
@@ -6,7 +6,7 @@ curl https://install.duckdb.org | sh
 export PATH=$HOME'/.duckdb/cli/latest':$PATH
 
 # Load the data
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 echo -n "Load time: "
 command time -f '%e' duckdb hits.db -storage_version latest -f create.sql -f load.sql

--- a/firebolt-parquet-partitioned/benchmark.sh
+++ b/firebolt-parquet-partitioned/benchmark.sh
@@ -3,8 +3,7 @@
 # Download the partitioned hits parquet files
 echo "Downloading dataset..."
 rm -rf data
-mkdir -p data
-seq 0 99 | xargs -P100 -I{} bash -c 'wget -P data --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned data
 
 # Start the container
 sudo apt-get install -y docker.io jq

--- a/firebolt-parquet/benchmark.sh
+++ b/firebolt-parquet/benchmark.sh
@@ -3,8 +3,7 @@
 # Download the hits.parquet file
 echo "Downloading dataset..."
 rm -rf data
-mkdir -p data
-wget -P data --continue --progress=dot:giga "https://datasets.clickhouse.com/hits_compatible/hits.parquet"
+../download-hits-parquet-single data
 
 # Start the container
 sudo apt-get install -y docker.io jq

--- a/firebolt/benchmark.sh
+++ b/firebolt/benchmark.sh
@@ -3,8 +3,7 @@
 # Download the hits.parquet file
 echo "Downloading dataset..."
 rm -rf data
-mkdir -p data
-wget -P data --continue --progress=dot:giga "https://datasets.clickhouse.com/hits_compatible/hits.parquet"
+../download-hits-parquet-single data
 
 # Start the container
 sudo apt-get install -y docker.io jq

--- a/gizmosql/benchmark.sh
+++ b/gizmosql/benchmark.sh
@@ -41,7 +41,7 @@ gizmosqlline \
   -f create.sql
 
 # Load the data
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 echo -n "Load time: "
 time gizmosqlline \

--- a/glaredb-partitioned/benchmark.sh
+++ b/glaredb-partitioned/benchmark.sh
@@ -17,10 +17,8 @@ else
 fi
 
 # Get the data.
-mkdir -p "${script_dir}/data"
+"${script_dir}/../download-hits-parquet-partitioned" "${script_dir}/data"
 pushd "${script_dir}/data"
-
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
 echo "Data size: $(du -bcs hits*.parquet | grep total)"
 echo "Load time: 0"
 popd

--- a/glaredb/benchmark.sh
+++ b/glaredb/benchmark.sh
@@ -17,10 +17,8 @@ else
 fi
 
 # Get the data.
-mkdir -p "${script_dir}/data"
+"${script_dir}/../download-hits-parquet-single" "${script_dir}/data"
 pushd "${script_dir}/data"
-
-wget --continue --progress=dot:giga https://clickhouse-public-datasets.s3.eu-central-1.amazonaws.com/hits_compatible/athena/hits.parquet
 echo "Data size: $(du -bcs hits*.parquet | grep total)"
 popd
 

--- a/greenplum/benchmark.sh
+++ b/greenplum/benchmark.sh
@@ -63,9 +63,7 @@ sudo mkdir /gpmaster /gpdata1 /gpdata2 /gpdata3 /gpdata4 /gpdata5 /gpdata6 /gpda
 sudo chmod 777 /gpmaster /gpdata1 /gpdata2 /gpdata3 /gpdata4 /gpdata5 /gpdata6 /gpdata7 /gpdata8 /gpdata9 /gpdata10 /gpdata11 /gpdata12 /gpdata13 /gpdata14
 gpinitsystem -ac gpinitsystem_singlenode
 export MASTER_DATA_DIRECTORY=/gpmaster/gpsne-1/
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 chmod 777 ~ hits.tsv
 psql -d postgres -f create.sql 2>&1 | tee load_out.txt
 if grep 'ERROR' load_out.txt

--- a/heavyai/benchmark.sh
+++ b/heavyai/benchmark.sh
@@ -32,9 +32,7 @@ sudo systemctl enable heavydb
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 chmod 777 ~ hits.csv
 
 sudo bash -c "echo 'allowed-import-paths = [\"$(pwd)\"]' > /var/lib/heavyai/heavy.conf_"

--- a/hologres/benchmark.sh
+++ b/hologres/benchmark.sh
@@ -19,9 +19,7 @@ FILENAME="hits.tsv"
 # Check if the file exists
 if [ ! -f "$FILENAME" ]; then
     echo "The file $FILENAME does not exist. Starting to download..."
-    sudo apt-get install -y pigz
-    wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-    pigz -d -f hits.tsv.gz
+    ../download-hits-tsv
     chmod 777 ~ hits.tsv
     if [ $? -eq 0 ]; then
         echo "File download completed!"

--- a/hyper-parquet/benchmark.sh
+++ b/hyper-parquet/benchmark.sh
@@ -6,7 +6,7 @@ python3 -m venv myenv
 source myenv/bin/activate
 pip install tableauhyperapi
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 
 ./run.sh | tee log.txt
 echo "Data size: $(du -bcs hits*.parquet | grep total)"

--- a/hyper/benchmark.sh
+++ b/hyper/benchmark.sh
@@ -6,9 +6,7 @@ python3 -m venv myenv
 source myenv/bin/activate
 pip install tableauhyperapi
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 
 echo -n "Load time: "
 command time -f '%e' ./load.py

--- a/infobright/benchmark.sh
+++ b/infobright/benchmark.sh
@@ -13,9 +13,7 @@ sudo docker run -i --rm --network host mysql:5 mysql --host 127.0.0.1 --port 502
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 # ERROR 2 (HY000) at line 1: Wrong data or column definition. Row: 93557187, field: 100.
 head -n 90000000 hits.tsv > hits90m.tsv

--- a/locustdb/benchmark.sh
+++ b/locustdb/benchmark.sh
@@ -15,9 +15,7 @@ sudo apt-get install -y g++ capnproto libclang-14-dev
 
 cargo build --features "enable_rocksdb" --features "enable_lz4" --release
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../../download-hits-csv
 
 target/release/repl --load hits.csv --db-path db
 

--- a/mariadb-columnstore/benchmark.sh
+++ b/mariadb-columnstore/benchmark.sh
@@ -21,9 +21,7 @@ mysql --password="${PASSWORD}" --host 127.0.0.1 clickbench < create.sql
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 echo -n "Load time: "
 command time -f '%e' mysql --password="${PASSWORD}" --host 127.0.0.1 clickbench -e "SET sql_log_bin = 0;

--- a/mariadb/benchmark.sh
+++ b/mariadb/benchmark.sh
@@ -14,9 +14,7 @@ sudo service mariadb restart
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 sudo mariadb -e "CREATE DATABASE test"
 sudo mariadb test < create.sql

--- a/monetdb/benchmark.sh
+++ b/monetdb/benchmark.sh
@@ -22,9 +22,7 @@ sudo apt-get install -y expect
 
 ./query.expect "$(cat create.sql)"
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 chmod 777 ~ hits.tsv
 
 echo -n "Load time: "

--- a/mongodb/benchmark.sh
+++ b/mongodb/benchmark.sh
@@ -68,9 +68,7 @@ time mongosh --quiet --eval 'db.hits.createIndex({"ClientIP": 1, "WatchID": 1, "
 
 #################################
 # Load data and import
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 # Use mongo import to load data into mongo. By default numInsertionWorkers is 1 so change to half of VM where it would be run
 #time mongoimport --collection hits --type tsv hits.tsv --fieldFile=create.txt --columnsHaveTypes --numInsertionWorkers=8

--- a/mysql-myisam/benchmark.sh
+++ b/mysql-myisam/benchmark.sh
@@ -9,9 +9,7 @@ sudo service mysql restart
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 sudo mysql -e "CREATE DATABASE test"
 sudo mysql test < create.sql

--- a/mysql/benchmark.sh
+++ b/mysql/benchmark.sh
@@ -9,9 +9,7 @@ sudo service mysql restart
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 sudo mysql -e "CREATE DATABASE test"
 sudo mysql test < create.sql

--- a/octosql/benchmark.sh
+++ b/octosql/benchmark.sh
@@ -3,7 +3,7 @@
 wget --continue --progress=dot:giga https://github.com/cube2222/octosql/releases/download/v0.13.0/octosql_0.13.0_linux_amd64.tar.gz
 tar xf octosql_0.13.0_linux_amd64.tar.gz
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 ./run.sh 2>&1 | tee log.txt
 

--- a/opteryx/benchmark.sh
+++ b/opteryx/benchmark.sh
@@ -18,8 +18,7 @@ source ~/opteryx_venv/bin/activate
 ~/opteryx_venv/bin/python -m pip install --upgrade opteryx==0.26.1
 
 # Download benchmark target data, partitioned
-mkdir -p hits
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix hits --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned hits
 
 # Run a simple query to check the installation
 ~/opteryx_venv/bin/python -m opteryx "SELECT version()" 2>&1

--- a/oxla/benchmark.sh
+++ b/oxla/benchmark.sh
@@ -8,11 +8,7 @@ sudo apt-get install -y postgresql-client curl wget apt-transport-https ca-certi
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential
 
 # download dataset
-echo "Download dataset."
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-echo "Unpack dataset."
-pigz -d -f hits.csv.gz
+../download-hits-csv
 sudo mkdir data
 sudo mv hits.csv data
 

--- a/pandas/benchmark.sh
+++ b/pandas/benchmark.sh
@@ -9,7 +9,7 @@ source myenv/bin/activate
 pip install pandas pyarrow
 
 # Download the data
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/paradedb-partitioned/benchmark.sh
+++ b/paradedb-partitioned/benchmark.sh
@@ -28,8 +28,7 @@ sudo docker run \
 echo ""
 echo "Downloading ClickBench dataset..."
 if [ ! -e /tmp/partitioned/ ]; then
-  mkdir -p /tmp/partitioned
-  seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix /tmp/partitioned --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+  ../download-hits-parquet-partitioned /tmp/partitioned
 fi
 if ! sudo docker exec paradedb sh -c '[ -f /tmp/partitioned ]'; then
   sudo docker cp /tmp/partitioned paradedb:tmp

--- a/paradedb/benchmark.sh
+++ b/paradedb/benchmark.sh
@@ -19,7 +19,7 @@ sudo docker run \
 
 echo "Downloading ClickBench dataset..."
 if [ ! -e /tmp/hits.parquet ]; then
-  wget --continue --progress=dot:giga -O /tmp/hits.parquet https://datasets.clickhouse.com/hits_compatible/hits.parquet
+  ../download-hits-parquet-single /tmp
 fi
 if ! sudo docker exec paradedb sh -c '[ -f /tmp/hits.parquet ]'; then
   sudo docker cp /tmp/hits.parquet paradedb:/tmp/hits.parquet

--- a/pg_duckdb-indexed/benchmark.sh
+++ b/pg_duckdb-indexed/benchmark.sh
@@ -5,9 +5,7 @@ set -eu
 sudo apt-get update -y
 sudo apt-get install -y docker.io postgresql-client
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 memory=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 threads=$(nproc)

--- a/pg_duckdb-parquet/benchmark.sh
+++ b/pg_duckdb-parquet/benchmark.sh
@@ -5,7 +5,7 @@ set -e
 sudo apt-get update -y
 sudo apt-get install -y docker.io postgresql-client
 
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 sudo docker run -d --name pgduck -p 5432:5432 -e POSTGRES_PASSWORD=duckdb -v ./hits.parquet:/tmp/hits.parquet pgduckdb/pgduckdb:17-v1.0.0 -c duckdb.max_memory=10GB
 
 for _ in {1..300}

--- a/pg_duckdb/benchmark.sh
+++ b/pg_duckdb/benchmark.sh
@@ -5,9 +5,7 @@ set -eu
 sudo apt-get update -y
 sudo apt-get install -y docker.io postgresql-client
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 memory=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 threads=$(nproc)

--- a/pg_ducklake/benchmark.sh
+++ b/pg_ducklake/benchmark.sh
@@ -5,7 +5,7 @@ set -e
 sudo apt-get update -y
 sudo apt-get install -y docker.io postgresql-client
 
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 docker run -d --name pgduck -p 5432:5432 -e POSTGRES_PASSWORD=duckdb -v ./hits.parquet:/tmp/hits.parquet pgducklake/pgducklake:18-main
 
 sleep 5 # wait for pgducklake start up

--- a/pg_mooncake/benchmark.sh
+++ b/pg_mooncake/benchmark.sh
@@ -10,7 +10,7 @@ newgrp docker
 
 sudo apt-get install -y postgresql-client
 
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 docker run -d --name pg_mooncake -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -v ./hits.parquet:/tmp/hits.parquet mooncakelabs/pg_mooncake:17-v0.1.0
 
 sleep 5

--- a/pinot/benchmark.sh
+++ b/pinot/benchmark.sh
@@ -17,8 +17,7 @@ sleep 30
 
 # Load the data
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-gzip -d -f hits.tsv.gz
+../download-hits-tsv
 
 # Pinot was unable to load data as a single file wihout any errors returned. We have to split the data
 echo -n "Load time: "

--- a/polars-dataframe/benchmark.sh
+++ b/polars-dataframe/benchmark.sh
@@ -9,7 +9,7 @@ source myenv/bin/activate
 pip install polars
 
 # Download the data
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/polars/benchmark.sh
+++ b/polars/benchmark.sh
@@ -9,7 +9,7 @@ source myenv/bin/activate
 pip install polars
 
 # Download the data
-wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena/hits.parquet
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/postgresql-indexed/benchmark.sh
+++ b/postgresql-indexed/benchmark.sh
@@ -50,9 +50,7 @@ EOF
 
 sudo systemctl restart postgresql@$PGVERSION-main
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 sudo -u postgres psql -t -c 'CREATE DATABASE test'
 sudo -u postgres psql test -t <create.sql 2>&1 | tee load_out.txt

--- a/postgresql/benchmark.sh
+++ b/postgresql/benchmark.sh
@@ -50,9 +50,7 @@ EOF
 
 sudo systemctl restart postgresql@$PGVERSION-main
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 sudo -u postgres psql -t -c 'CREATE DATABASE test'
 sudo -u postgres psql test -t <create.sql 2>&1 | tee load_out.txt

--- a/questdb/benchmark.sh
+++ b/questdb/benchmark.sh
@@ -31,9 +31,7 @@ questdb/bin/questdb.sh start
 
 # Import the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 
 curl -G --data-urlencode "query=$(cat create.sql)" 'http://localhost:9000/exec'
 

--- a/sail-partitioned/benchmark.sh
+++ b/sail-partitioned/benchmark.sh
@@ -53,8 +53,7 @@ pip install "pyspark-client==4.1.1" \
 # Load the data
 
 echo "Download benchmark target data, partitioned"
-mkdir -p partitioned
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --directory-prefix partitioned --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned partitioned
 
 # Run the queries
 

--- a/sail/benchmark.sh
+++ b/sail/benchmark.sh
@@ -53,7 +53,7 @@ pip install "pyspark-client==4.1.1" \
 # Load the data
 
 echo "Download benchmark target data, single file"
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/selectdb/benchmark.sh
+++ b/selectdb/benchmark.sh
@@ -93,9 +93,7 @@ mysql -h 127.0.0.1 -P9030 -uroot hits <"$ROOT"/create.sql
 
 # Download data
 if [[ ! -f hits.tsv.gz ]] && [[ ! -f hits.tsv ]]; then
-    sudo apt-get install -y pigz
-    wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-    pigz -d -f hits.tsv.gz
+    ../download-hits-tsv
 fi
 
 # Load data

--- a/singlestore/benchmark.sh
+++ b/singlestore/benchmark.sh
@@ -21,9 +21,7 @@ sudo docker exec -i memsql-ciab memsql -p"${ROOT_PASSWORD}"
 
 # Load the data
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 sudo docker cp hits.tsv memsql-ciab:/
 
 sudo docker exec -i memsql-ciab memsql -p"${ROOT_PASSWORD}" -e "CREATE DATABASE test"

--- a/sirius/benchmark.sh
+++ b/sirius/benchmark.sh
@@ -35,7 +35,7 @@ set +e
 # ---------------------------------------------------------------------------
 # 2. Load data
 # ---------------------------------------------------------------------------
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 echo -n "Load time: "
 command time -f '%e' duckdb hits.db -f create.sql -f load.sql

--- a/spark-auron/benchmark.sh
+++ b/spark-auron/benchmark.sh
@@ -21,7 +21,7 @@ pip install pyspark==3.5.5 psutil
 
 # Load the data
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Install Auron
 

--- a/spark-comet/benchmark.sh
+++ b/spark-comet/benchmark.sh
@@ -21,7 +21,7 @@ pip install pyspark==3.5.6 psutil
 
 # Load the data
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Install Comet
 

--- a/spark-gluten/benchmark.sh
+++ b/spark-gluten/benchmark.sh
@@ -21,7 +21,7 @@ pip install pyspark==3.5.2 psutil
 
 # Load the data
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Install Gluten
 

--- a/spark/benchmark.sh
+++ b/spark/benchmark.sh
@@ -16,7 +16,7 @@ pip install pyspark==4.0.0 psutil
 
 # Load the data
 
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.parquet'
+../download-hits-parquet-single
 
 # Run the queries
 

--- a/sqlite/benchmark.sh
+++ b/sqlite/benchmark.sh
@@ -5,9 +5,7 @@ sudo apt-get install -y sqlite3
 
 sqlite3 mydb < create.sql
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 
 echo -n "Load time: "
 command time -f '%e' sqlite3 mydb '.import --csv hits.csv hits'

--- a/starrocks/benchmark.sh
+++ b/starrocks/benchmark.sh
@@ -46,9 +46,7 @@ sleep 30
 
 # Prepare Data
 cd ../
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 # Create Table
 mysql -h 127.0.0.1 -P9030 -uroot -e "CREATE DATABASE hits"

--- a/supabase/benchmark.sh
+++ b/supabase/benchmark.sh
@@ -12,9 +12,7 @@ sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 sudo apt-get update -y
 sudo apt-get install -y postgresql-$PGVERSION
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 psql ${SUPABASE_CONNECTION_STRING} -c 'CREATE DATABASE test'
 psql ${SUPABASE_CONNECTION_STRING} -t <create.sql 2>&1 | tee load_out.txt

--- a/tablespace/benchmark.sh
+++ b/tablespace/benchmark.sh
@@ -6,9 +6,7 @@ PASSWORD="<tablespace-db-password>"
 sudo apt-get update -y
 sudo apt-get install -y postgresql-client
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 chmod 777 ~ hits.tsv
 
 psql "host=$HOSTNAME port=5432 dbname=csdb user=csuser password=$PASSWORD sslmode=require" < create.sql 2>&1 | tee load_out.txt

--- a/tembo-olap/benchmark.sh
+++ b/tembo-olap/benchmark.sh
@@ -6,9 +6,7 @@ PASSWORD="<password>"
 sudo apt-get update -y
 sudo apt-get install -y postgresql-client
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 chmod 777 ~ hits.tsv
 
 psql postgresql://postgres:$PASSWORD@$HOSTNAME:5432 -t -c 'CREATE DATABASE test'

--- a/timescaledb-no-columnstore/benchmark.sh
+++ b/timescaledb-no-columnstore/benchmark.sh
@@ -16,9 +16,7 @@ sudo systemctl restart postgresql
 sudo -u postgres psql -c "CREATE DATABASE nocolumnstore"
 sudo -u postgres psql nocolumnstore -c "CREATE EXTENSION timescaledb WITH VERSION '2.17.2';"
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 sudo chmod og+rX ~
 chmod 777 hits.tsv
 

--- a/timescaledb/benchmark.sh
+++ b/timescaledb/benchmark.sh
@@ -17,9 +17,7 @@ sudo -u postgres psql -c "CREATE DATABASE test"
 sudo -u postgres psql test -c "CREATE EXTENSION timescaledb WITH VERSION '2.17.2';"
 
 # Import the data
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 sudo chmod og+rX ~
 chmod 777 hits.tsv
 

--- a/turso/benchmark.sh
+++ b/turso/benchmark.sh
@@ -10,9 +10,7 @@ source $HOME/.turso/env
 
 tursodb mydb < create.sql
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-pigz -d -f hits.csv.gz
+../download-hits-csv
 
 echo -n "Load time: "
 command time -f '%e' tursodb mydb '.import --csv hits.csv hits'

--- a/umbra/benchmark.sh
+++ b/umbra/benchmark.sh
@@ -10,9 +10,7 @@ sudo apt-get install -y docker.io postgresql-client gzip
 # Download + uncompress hits
 rm -rf data
 mkdir data
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 mv hits.tsv data
 chmod 777 -R data
 

--- a/ursa/benchmark.sh
+++ b/ursa/benchmark.sh
@@ -17,7 +17,7 @@ done
 
 ./ursa client < create.sql
 
-seq 0 99 | xargs -P100 -I{} bash -c 'wget --continue --progress=dot:giga https://datasets.clickhouse.com/hits_compatible/athena_partitioned/hits_{}.parquet'
+../download-hits-parquet-partitioned
 sudo mv hits_*.parquet user_files/
 sudo chown clickhouse:clickhouse user_files/hits_*.parquet
 

--- a/vertica/benchmark.sh
+++ b/vertica/benchmark.sh
@@ -7,9 +7,7 @@ sudo docker run -p 5433:5433 -p 5444:5444 --volume $(pwd):/workdir --mount type=
 
 sudo docker exec vertica_ce /opt/vertica/bin/vsql -U dbadmin -c "$(cat create.sql)"
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 echo -n "Load time: "
 command time -f '%e' sudo docker exec vertica_ce /opt/vertica/bin/vsql -U dbadmin -c "COPY hits FROM LOCAL '/workdir/hits.tsv' DELIMITER E'\\t' NULL E'\\001' DIRECT"

--- a/yugabytedb/benchmark.sh
+++ b/yugabytedb/benchmark.sh
@@ -19,9 +19,7 @@ mv ./yugabyte-$YDBVERSION ./yugabyte
 
 ./yugabyte/bin/yugabyted start --advertise_address 127.0.0.1 --ui false --background true
 
-sudo apt-get install -y pigz
-wget --continue --progress=dot:giga 'https://datasets.clickhouse.com/hits_compatible/hits.tsv.gz'
-pigz -d -f hits.tsv.gz
+../download-hits-tsv
 
 ./yugabyte/bin/ysqlsh -U yugabyte -c "CREATE DATABASE test;"
 ./yugabyte/bin/ysqlsh -U yugabyte -c "ALTER DATABASE test SET temp_file_limit=-1;"


### PR DESCRIPTION
## Summary
- Introduce four executable scripts at the repo root — `download-hits-tsv`, `download-hits-csv`, `download-hits-parquet-single`, `download-hits-parquet-partitioned` — each accepting an optional destination directory as its first argument
- Replace duplicated wget/pigz blocks across 82 benchmarks with calls to the shared scripts
- Standardize parquet downloads on the Athena-compatible variant (`hits_compatible/athena/hits.parquet`); the hardware benchmark uses a different dataset and is unchanged

Eleven benchmarks keep their existing download logic because they aren't simple duplication: running as a different user (cloudberry), downloading inside a docker container (pgpro_tam), keeping the .gz file (byconity), not unpacking (kinetica), in-SQL ingestion via \`url()\` (clickhouse-cloud), or custom size-verification flow (arc), among others.

## Test plan
- [ ] Spot-run a TSV-based benchmark (e.g. \`postgresql\`) and confirm the dataset is fetched and decompressed via the new script
- [ ] Spot-run a CSV-based benchmark (e.g. \`sqlite\`) similarly
- [ ] Spot-run a single-parquet benchmark (e.g. \`duckdb\`) and confirm queries succeed against the Athena-variant parquet
- [ ] Spot-run a partitioned-parquet benchmark (e.g. \`clickhouse\`)
- [ ] Verify destination-dir argument works for benchmarks that need a non-pwd target (e.g. \`firebolt\`, \`paradedb\`, \`doris-parquet\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)