### PR TITLE
GizmoSQL: switch from gizmosqlline (Java) to gizmosql_client

### DIFF
--- a/gizmosql/benchmark.sh
+++ b/gizmosql/benchmark.sh
@@ -4,8 +4,8 @@
 export HOME=/home/ubuntu
 
 # Install requirements
-apt-get update -y
-apt install unzip netcat-openbsd -y
+sudo apt-get update -y
+sudo apt-get install -y unzip netcat-openbsd
 
 # Detect architecture (maps x86_64->amd64, aarch64->arm64)
 ARCH=$(uname -m)
@@ -15,10 +15,12 @@ elif [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
-# Install the GizmoSQL server and client (gizmosql_client is the CLI shell)
+# Install the GizmoSQL server and client (gizmosql_client is the CLI shell) into a local directory
+mkdir -p ./bin
 curl -L -o gizmosql.zip "https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_linux_${ARCH}.zip"
-unzip gizmosql.zip
-mv gizmosql_server gizmosql_client /usr/local/bin/
+unzip -o gizmosql.zip -d ./bin
+chmod +x ./bin/gizmosql_server ./bin/gizmosql_client
+export PATH="$PWD/bin:$PATH"
 
 # Source our env vars and utility functions for starting/stopping gizmosql server
 . util.sh

--- a/gizmosql/benchmark.sh
+++ b/gizmosql/benchmark.sh
@@ -5,7 +5,7 @@ export HOME=/home/ubuntu
 
 # Install requirements
 apt-get update -y
-apt install openjdk-17-jre-headless unzip netcat-openbsd -y
+apt install unzip netcat-openbsd -y
 
 # Detect architecture (maps x86_64->amd64, aarch64->arm64)
 ARCH=$(uname -m)
@@ -15,17 +15,10 @@ elif [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
-# Server setup Install
+# Install the GizmoSQL server and client (gizmosql_client is the CLI shell)
 curl -L -o gizmosql.zip "https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_linux_${ARCH}.zip"
 unzip gizmosql.zip
 mv gizmosql_server gizmosql_client /usr/local/bin/
-
-# Install Java and the GizmoSQLLine CLI client
-pushd /tmp
-curl -L -o gizmosqlline https://github.com/gizmodata/gizmosqlline/releases/latest/download/gizmosqlline
-chmod +x gizmosqlline
-mv gizmosqlline /usr/local/bin/
-popd
 
 # Source our env vars and utility functions for starting/stopping gizmosql server
 . util.sh
@@ -34,21 +27,13 @@ popd
 start_gizmosql
 
 # Create the table
-gizmosqlline \
-  -u ${GIZMOSQL_SERVER_URI} \
-  -n ${GIZMOSQL_USERNAME} \
-  -p ${GIZMOSQL_PASSWORD} \
-  -f create.sql
+gizmosql_client --file create.sql
 
 # Load the data
 ../download-hits-parquet-single
 
 echo -n "Load time: "
-time gizmosqlline \
-  -u ${GIZMOSQL_SERVER_URI} \
-  -n ${GIZMOSQL_USERNAME} \
-  -p ${GIZMOSQL_PASSWORD} \
-  -f load.sql
+time gizmosql_client --file load.sql
 
 stop_gizmosql
 
@@ -62,8 +47,8 @@ echo -n "Data size: "
 wc -c clickbench.db
 
 cat log.txt | \
-  grep -E 'rows? selected \([0-9.]+ seconds\)|Killed|Segmentation' | \
-  sed -E 's/.*rows? selected \(([0-9.]+) seconds\).*/\1/; s/.*(Killed|Segmentation).*/null/' | \
+  grep -E 'Run Time: [0-9.]+s|Killed|Segmentation' | \
+  sed -E 's/.*Run Time: ([0-9.]+)s.*/\1/; s/.*(Killed|Segmentation).*/null/' | \
   awk '{
     if (NR % 3 == 1) printf "[";
     if ($1 == "null") printf "null";

--- a/gizmosql/run.sh
+++ b/gizmosql/run.sh
@@ -24,6 +24,10 @@ for query in "${queries[@]}"; do
     # Start the GizmoSQL server
     start_gizmosql
 
+    # Enable timer and discard result rows (we only care about Run Time)
+    echo ".timer on" >> "${TEMP_SQL_FILE}"
+    echo ".mode trash" >> "${TEMP_SQL_FILE}"
+
     # Add a comment to identify the query in the output
     echo "-- Query: ${query}" >> "${TEMP_SQL_FILE}"
 
@@ -32,12 +36,8 @@ for query in "${queries[@]}"; do
         echo "${query}" >> "${TEMP_SQL_FILE}"
     done
 
-    # Execute the query script
-    gizmosqlline \
-        -u ${GIZMOSQL_SERVER_URI} \
-        -n ${GIZMOSQL_USERNAME} \
-        -p ${GIZMOSQL_PASSWORD} \
-        -f "${TEMP_SQL_FILE}"
+    # Execute the query script (timer output goes to stderr; merge to stdout)
+    gizmosql_client --file "${TEMP_SQL_FILE}" 2>&1
 
     # Stop the server before next query
     stop_gizmosql

--- a/gizmosql/run.sh
+++ b/gizmosql/run.sh
@@ -19,7 +19,7 @@ for query in "${queries[@]}"; do
 
     # Clear Linux memory caches to ensure fair benchmark comparisons
     sync
-    echo 3 | tee /proc/sys/vm/drop_caches > /dev/null
+    echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null
 
     # Start the GizmoSQL server
     start_gizmosql

--- a/gizmosql/util.sh
+++ b/gizmosql/util.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-# Variables
-GIZMOSQL_SERVER_URI="jdbc:arrow-flight-sql://localhost:31337?useEncryption=false"
-GIZMOSQL_USERNAME=clickbench
-GIZMOSQL_PASSWORD=clickbench
+# Variables (env var names match what gizmosql_client recognizes natively)
+export GIZMOSQL_HOST=localhost
+export GIZMOSQL_PORT=31337
+export GIZMOSQL_USER=clickbench
+export GIZMOSQL_PASSWORD=clickbench
 PID_FILE="/tmp/gizmosql_server_$$.pid"
 
 # Function to start the GizmoSQL server
 start_gizmosql() {
-    export GIZMOSQL_PASSWORD="${GIZMOSQL_PASSWORD}"
-
     nohup gizmosql_server \
-        --username ${GIZMOSQL_USERNAME} \
+        --username ${GIZMOSQL_USER} \
         --database-filename clickbench.db \
         --print-queries >> gizmosql_server.log 2>&1 &
 
@@ -19,7 +18,7 @@ start_gizmosql() {
 
     # Wait for server to be ready
     echo "Waiting for gizmosql_server to start..."
-    while ! nc -z localhost 31337 2>/dev/null; do
+    while ! nc -z ${GIZMOSQL_HOST} ${GIZMOSQL_PORT} 2>/dev/null; do
         sleep 1
     done
     echo "gizmosql_server is ready (PID: $(cat ${PID_FILE}))"


### PR DESCRIPTION
## Summary

Switches the GizmoSQL ClickBench scripts from the Java-based `gizmosqlline` SQLLine client to the new C++ `gizmosql_client` shell that ships in the same release archive as `gizmosql_server`.

- Drops the `openjdk-17-jre-headless` apt install and the separate `gizmosqlline` binary download — `gizmosql_client` is already in `gizmosql_cli_linux_${ARCH}.zip`.
- Replaces `gizmosqlline -u <jdbc-uri> -n -p -f` invocations with `gizmosql_client --file ...`, which reads connection parameters from the `GIZMOSQL_HOST` / `GIZMOSQL_PORT` / `GIZMOSQL_USER` / `GIZMOSQL_PASSWORD` env vars natively.
- In `run.sh`, prepends `.timer on` and `.mode trash` to each per-query batch so the client emits one `Run Time: X.XXs` line per statement (to stderr) and skips rendering result rows. stderr is merged into stdout for log capture.
- Updates the result parser regex in `benchmark.sh` from sqlline's `rows? selected ([0-9.]+ seconds)` to `Run Time: [0-9.]+s`.

See https://docs.gizmosql.com/#/client for full client usage.

## Test plan

- [x] Smoke-tested locally with `gizmosql_server` / `gizmosql_client` v1.22.4 on a small in-memory table; the `Run Time: X.XXs` parser produced the expected `[t1, t2, t3],` output rows.
- [ ] Full ClickBench run on a Linux host (the cache-drop and apt steps are Linux-only).
