### PR TITLE
Revert #874: restore previous generate-results.sh behavior

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -1,37 +1,33 @@
 #!/bin/bash -e
 
 # Results live under <system>/results/YYYYMMDD/<basename>.json.
-# For the website we use only the latest date subdirectory of each
-# system's results/, and include every file in that subdirectory.
-# Older subdirectories are kept on disk as history but not displayed.
-# Entries tagged "historical" are also filtered out.
+# For the website we keep only the latest dated copy per (system, basename),
+# and we skip entries tagged "historical" — those are kept in the repo
+# as archival data but are not displayed on the dashboard.
 
 echo "const data = [" > data.generated.js.new
 FIRST=1
 
-for dir in */; do
-    dir="${dir%/}"
-    case "$dir" in
-        hardware|versions|gravitons) continue;;
-    esac
-    [ -d "$dir/results" ] || continue
-    latest=$(LANG=C ls -1 "$dir/results" 2>/dev/null | sort | tail -1)
-    [ -n "$latest" ] || continue
-    [ -d "$dir/results/$latest" ] || continue
-
-    for file in "$dir/results/$latest"/*.json; do
-        [ -f "$file" ] || continue
-        if ! entry=$(jq --compact-output --arg src "$file" \
-            'select((.tags // []) | index("historical") | not) | . + {"source": $src}' \
-            "$file"); then
-            echo "Error in $file — skipping" >&2
-            continue
-        fi
-        [ -z "$entry" ] && continue
-        [ "${FIRST}" = "0" ] && echo -n ','
-        printf '%s\n' "$entry"
-        FIRST=0
-    done
+# Build "<system>/<basename> <full-path>" lines, then keep the last (latest)
+# row per key — sorted ascending by date, since YYYYMMDD sorts lexically.
+LANG="" ls -1 */results/*/*.json \
+    | grep -Ev '^(hardware|versions|gravitons)/' \
+    | sort \
+    | awk -F/ '{ print $1"/"$NF" "$0 }' \
+    | awk '{ latest[$1] = $2 } END { for (k in latest) print latest[k] }' \
+    | sort \
+    | while read -r file
+do
+    if ! entry=$(jq --compact-output --arg src "$file" \
+        'select((.tags // []) | index("historical") | not) | . + {"source": $src}' \
+        "$file"); then
+        echo "Error in $file — skipping" >&2
+        continue
+    fi
+    [ -z "$entry" ] && continue
+    [ "${FIRST}" = "0" ] && echo -n ','
+    printf '%s\n' "$entry"
+    FIRST=0
 done >> data.generated.js.new
 echo '];' >> data.generated.js.new
 


### PR DESCRIPTION
Reverts #874 ("Use only the latest date subdir of each system for the dashboard").

Only the script change in `generate-results.sh` is reverted; `data.generated.js` is left at its current main state (it will be regenerated by the website build bot).