### PR TITLE
Skip queries that fail on every filtered system

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,15 +728,18 @@ function relativeQueryTime(num_queries, baseline_data, elem, metric) {
 
     for (let i = 0; i < num_queries; ++i) {
         if (no_queries_selected || selectors.queries[i]) {
-            const curr_timing = selectRun(elem.result[i], metric) ?? fallback_timing;
             const baseline_timing = selectRun(baseline_data[i], metric);
+            /// Skip queries that fail on every filtered system - otherwise the
+            /// geometric mean collapses to 0 and no bars render.
+            if (baseline_timing === null || !isFinite(baseline_timing)) continue;
+            const curr_timing = selectRun(elem.result[i], metric) ?? fallback_timing;
             const ratio = (constant_time_add + curr_timing) / (constant_time_add + baseline_timing);
             accumulator += Math.log(ratio);
             ++used_queries;
         }
     }
 
-    return Math.exp(accumulator / used_queries);
+    return used_queries > 0 ? Math.exp(accumulator / used_queries) : null;
 }
 
 function addNote(text) {


### PR DESCRIPTION
## Summary
- When every selected system returns null for a query, the per-query baseline becomes `Math.min()` over an empty set (`Infinity`), so `log(curr / Infinity) = -Infinity` collapses every system's geometric mean to 0. All bars then render with width 0 and the chart appears empty.
- Fix: in `relativeQueryTime`, skip queries whose baseline is non-finite, and return `null` if no queries remain.

## Reproduction
Filter on the dashboard to Elasticsearch + Quickwit (e.g. [this URL](https://benchmark.clickhouse.com/#system=+tsc|Qiit&type=-&machine=-&cluster_size=-&opensource=-&hardware=+c&tuned=+n&metric=combined&queries=-)) — Q28 (`REGEXP_REPLACE`) fails on both, and the bar chart vanishes. With the fix, Q28 is skipped from the geometric mean and bars render normally.

## Test plan
- [x] Reproduce empty chart with Elasticsearch + Quickwit filter on current main
- [x] Verify ratios are non-zero after the fix (cold/hot summaries computed locally)
- [ ] Spot-check that detail rows still show ☠ for Q28 and that other filter combinations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)