### PR TITLE
Normalize Motherduck Jumbo to jumbo

### DIFF
--- a/pg_duckdb-motherduck/results/20240307/motherduck.json
+++ b/pg_duckdb-motherduck/results/20240307/motherduck.json
@@ -1,7 +1,7 @@
 {
     "system": "pg_duckdb (MotherDuck enabled)",
     "date": "2024-03-07",
-    "machine": "Motherduck: Jumbo",
+    "machine": "Motherduck: jumbo",
     "cluster_size": "serverless",
     "proprietary": "yes",
     "hardware": "cpu",

--- a/pg_duckdb-motherduck/results/20241123/motherduck.json
+++ b/pg_duckdb-motherduck/results/20241123/motherduck.json
@@ -1,7 +1,7 @@
 {
     "system": "pg_duckdb (MotherDuck enabled)",
     "date": "2024-11-23",
-    "machine": "Motherduck: Jumbo",
+    "machine": "Motherduck: jumbo",
     "cluster_size": "serverless",
     "proprietary": "yes",
     "hardware": "cpu",

--- a/pg_duckdb-motherduck/results/20250904/motherduck.json
+++ b/pg_duckdb-motherduck/results/20250904/motherduck.json
@@ -1,7 +1,7 @@
 {
     "system": "pg_duckdb (MotherDuck enabled)",
     "date": "2025-09-04",
-    "machine": "Motherduck: Jumbo",
+    "machine": "Motherduck: jumbo",
     "cluster_size": "serverless",
     "proprietary": "yes",
     "hardware": "cpu",


### PR DESCRIPTION
## Summary

`motherduck/` uses lowercase tier names (`Motherduck: jumbo`,
`Motherduck: mega`, `Motherduck: standard`); `pg_duckdb-motherduck/`
had three files with `Motherduck: Jumbo` (capital J). Lower-case the
J so the dashboard groups all jumbo-tier runs under one machine
label.

Files affected:
- `pg_duckdb-motherduck/results/20240307/motherduck.json`
- `pg_duckdb-motherduck/results/20241123/motherduck.json`
- `pg_duckdb-motherduck/results/20250904/motherduck.json`

## Test plan

- [ ] Spot-check the dashboard locally: jumbo-tier Motherduck runs
      from both `motherduck/` and `pg_duckdb-motherduck/` cluster
      under a single machine row

🤖 Generated with [Claude Code](https://claude.com/claude-code)