### PR TITLE
GizmoSQL: add support for specifying storage version in util.sh

### DIFF
--- a/gizmosql/util.sh
+++ b/gizmosql/util.sh
@@ -12,6 +12,7 @@ start_gizmosql() {
     nohup gizmosql_server \
         --username ${GIZMOSQL_USER} \
         --database-filename clickbench.db \
+        --storage-version latest \
         --print-queries >> gizmosql_server.log 2>&1 &
 
     echo $! > "${PID_FILE}"


### PR DESCRIPTION
In this PR, I am updating the GizmoSQL server start line to use the latest version for the database file format.