### PR TITLE
Update index.html to assume hardware is CPU if not specified. It got broken in recent change, causing some systems to be hidden.

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,7 +777,7 @@ function applyTopRowFilters() {
     const matches = data.filter(elem =>
         ((selectors.tuned.yes && elem.tuned === "yes") || (selectors.tuned.no && elem.tuned === "no")) &&
         ((selectors.opensource.yes && elem.proprietary === "no") || (selectors.opensource.no && elem.proprietary === "yes")) &&
-        ((selectors.hardware.cpu && elem.hardware === "cpu") || (selectors.hardware.gpu && elem.hardware === "gpu")));
+        ((selectors.hardware.cpu && (elem.hardware === "cpu" || !elem.hardware)) || (selectors.hardware.gpu && elem.hardware === "gpu")));
 
     function apply(container, getValues) {
         const allowed = new Set(matches.flatMap(getValues).map(x => String(x)));
@@ -1083,7 +1083,7 @@ function render() {
         elem.tags.filter(type => selectors.type[type]).length > 0 &&
         ((selectors.tuned.yes && elem.tuned === "yes") || (selectors.tuned.no && elem.tuned === "no")) &&
         ((selectors.opensource.yes && elem.proprietary === "no") || (selectors.opensource.no && elem.proprietary === "yes")) &&
-        ((selectors.hardware.cpu && elem.hardware === "cpu") || (selectors.hardware.gpu && elem.hardware === "gpu"))
+        ((selectors.hardware.cpu && (elem.hardware === "cpu" || !elem.hardware)) || (selectors.hardware.gpu && elem.hardware === "gpu"))
         );
 
     /// Filter out unreasonable entries


### PR DESCRIPTION
After recent updates a number of databases are not shown during filtering because hardware is not specified. This change assume hardware is CPU when it's missing.

Another option is to add hardware to all results, but that's 2K files and will be a larger change.

Tested locally and BigQuery and other options are shown on the dashboard again.

cc: @alexey-milovidov (Fixes filtering issue caused by the recent historical data restructuring).