### PR TITLE
cloudberry/data-size: run du inside the container

### DIFF
--- a/cloudberry/data-size
+++ b/cloudberry/data-size
@@ -1,4 +1,9 @@
 #!/bin/bash
+# The cluster's data lives inside the container under /data0, not on the
+# host. Run du inside the container so we see the actual bytes.
 set -eu
 
-sudo du -bcs /data0 2>/dev/null | grep total | awk '{print $1}'
+NAME=clickbench-cloudberry
+
+sudo docker exec "$NAME" du -bcs /data0 2>/dev/null | \
+    awk '/total$/ { print $1 }'


### PR DESCRIPTION
## Summary
- Cloudberry's cluster data lives inside the docker container under `/data0`, but `cloudberry/data-size` was running `sudo du -bcs /data0` on the host.
- That returned `0` bytes even after a successful load, and the post-load sanity guard in `lib/benchmark-common.sh:197` then aborted the run as "partial / likely OOM kill mid-COPY" — even though 100M rows had actually loaded.
- Fix mirrors `warehousepg/data-size`, which already runs `du` inside the container via `docker exec`.

Observed in the latest t3a.small run from the sink log:
```
INSERT 0 99997497
ANALYZE
Load time: 9662.382
bench: data-size after load is '0' (<5 GB)
bench: ClickBench's hits dataset doesn't fit in <5 GB on any
bench: system in the catalog; treating this as a partial load
bench: (likely an OOM kill mid-COPY).
```

## Test plan
- [ ] Re-run cloudberry benchmark; `data-size` should now report a value >5 GB and the run should proceed to the query phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)