### PR TITLE
Add "Greenplum derivative" tag to Greenplum-family systems

### DIFF
--- a/cloudberry/results/20240606/c6a.4xlarge.json
+++ b/cloudberry/results/20240606/c6a.4xlarge.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "14 segments, ORCA enabled",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run", "Greenplum derivative"],
 
     "load_time": 601,
     "data_size": 36000000000,

--- a/cloudberry/template.json
+++ b/cloudberry/template.json
@@ -7,6 +7,7 @@
     "C",
     "column-oriented",
     "PostgreSQL compatible",
-    "lukewarm-cold-run"
+    "lukewarm-cold-run",
+    "Greenplum derivative"
   ]
 }

--- a/greengage/results/20260516/c6a.4xlarge.json
+++ b/greengage/results/20260516/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1246,
     "data_size": 38868780004,
     "concurrent_qps": 0.172,

--- a/greengage/results/20260516/c6a.metal.json
+++ b/greengage/results/20260516/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 598,
     "data_size": 39316144057,
     "concurrent_qps": 1.1280000000000001,

--- a/greengage/results/20260516/c7a.metal-48xl.json
+++ b/greengage/results/20260516/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 567,
     "data_size": 39493787555,
     "concurrent_qps": 1.435,

--- a/greengage/results/20260517/c6a.2xlarge.json
+++ b/greengage/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1313,
     "data_size": 39985515009,
     "concurrent_qps": 0.105,

--- a/greengage/results/20260517/c6a.4xlarge.json
+++ b/greengage/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1243,
     "data_size": 39057402472,
     "concurrent_qps": 0.17,

--- a/greengage/results/20260517/c6a.xlarge.json
+++ b/greengage/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 2171,
     "data_size": 40040087523,
     "concurrent_qps": 0.027,

--- a/greengage/template.json
+++ b/greengage/template.json
@@ -7,6 +7,7 @@
     "C",
     "column-oriented",
     "PostgreSQL compatible",
-    "lukewarm-cold-run"
+    "lukewarm-cold-run",
+    "Greenplum derivative"
   ]
 }

--- a/greenplum/results/20161221/historical-100m-2node.json
+++ b/greenplum/results/20161221/historical-100m-2node.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20161221/historical-100m.json
+++ b/greenplum/results/20161221/historical-100m.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20161221/historical-10m-2node.json
+++ b/greenplum/results/20161221/historical-10m-2node.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20161221/historical-10m.json
+++ b/greenplum/results/20161221/historical-10m.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20161221/historical-1b-2node.json
+++ b/greenplum/results/20161221/historical-1b-2node.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20161221/historical-1b.json
+++ b/greenplum/results/20161221/historical-1b.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "historical"
+        "historical",
+        "Greenplum derivative"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/greenplum/results/20220701/c6a.4xlarge.json
+++ b/greenplum/results/20220701/c6a.4xlarge.json
@@ -11,7 +11,8 @@
         "C",
         "column-oriented",
         "PostgreSQL compatible",
-        "lukewarm-cold-run"
+        "lukewarm-cold-run",
+        "Greenplum derivative"
     ],
     "load_time": 1080,
     "data_size": 42000000000,

--- a/greenplum/results/20220818/c6a.4xlarge.json
+++ b/greenplum/results/20220818/c6a.4xlarge.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "lukewarm-cold-run", "Greenplum derivative"],
 
     "load_time": 1080,
     "data_size": 42000000000,

--- a/greenplum/results/20260509/c6a.4xlarge.json
+++ b/greenplum/results/20260509/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1234,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c6a.2xlarge.json
+++ b/greenplum/results/20260510/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1245,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c6a.4xlarge.json
+++ b/greenplum/results/20260510/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1231,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c6a.large.json
+++ b/greenplum/results/20260510/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1802,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c6a.metal.json
+++ b/greenplum/results/20260510/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 872,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c7a.metal-48xl.json
+++ b/greenplum/results/20260510/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 822,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c8g.4xlarge.json
+++ b/greenplum/results/20260510/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1194,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260510/c8g.metal-48xl.json
+++ b/greenplum/results/20260510/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 846,
     "data_size": 19342459105,
     "result": [

--- a/greenplum/results/20260517/c6a.2xlarge.json
+++ b/greenplum/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1257,
     "data_size": 19342459105,
     "concurrent_qps": 0.112,

--- a/greenplum/results/20260517/c6a.4xlarge.json
+++ b/greenplum/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1241,
     "data_size": 19342459105,
     "concurrent_qps": 0.138,

--- a/greenplum/results/20260517/c6a.large.json
+++ b/greenplum/results/20260517/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1797,
     "data_size": 19342459105,
     "concurrent_qps": 0.048,

--- a/greenplum/results/20260517/c6a.metal.json
+++ b/greenplum/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 869,
     "data_size": 19342459105,
     "concurrent_qps": 0.533,

--- a/greenplum/results/20260517/c6a.xlarge.json
+++ b/greenplum/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1411,
     "data_size": 19342459105,
     "concurrent_qps": 0.075,

--- a/greenplum/results/20260517/c7a.metal-48xl.json
+++ b/greenplum/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 831,
     "data_size": 19342459105,
     "concurrent_qps": 0.61,

--- a/greenplum/results/20260517/c8g.4xlarge.json
+++ b/greenplum/results/20260517/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 1267,
     "data_size": 19342459105,
     "concurrent_qps": 0.145,

--- a/greenplum/results/20260517/c8g.metal-48xl.json
+++ b/greenplum/results/20260517/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","Greenplum derivative"],
     "load_time": 843,
     "data_size": 19342459105,
     "concurrent_qps": 0.53,

--- a/greenplum/template.json
+++ b/greenplum/template.json
@@ -6,6 +6,7 @@
   "tags": [
     "C",
     "column-oriented",
-    "PostgreSQL compatible"
+    "PostgreSQL compatible",
+    "Greenplum derivative"
   ]
 }

--- a/opengpdb/results/20260516/c6a.4xlarge.json
+++ b/opengpdb/results/20260516/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1242,
     "data_size": 38908741386,
     "concurrent_qps": 0.167,

--- a/opengpdb/results/20260516/c6a.metal.json
+++ b/opengpdb/results/20260516/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 596,
     "data_size": 39384372116,
     "concurrent_qps": 1.187,

--- a/opengpdb/results/20260516/c7a.metal-48xl.json
+++ b/opengpdb/results/20260516/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 562,
     "data_size": 39230263201,
     "concurrent_qps": 1.5430000000000001,

--- a/opengpdb/results/20260517/c6a.2xlarge.json
+++ b/opengpdb/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1315,
     "data_size": 39558372516,
     "concurrent_qps": 0.108,

--- a/opengpdb/results/20260517/c6a.4xlarge.json
+++ b/opengpdb/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1251,
     "data_size": 38903138203,
     "concurrent_qps": 0.173,

--- a/opengpdb/results/20260517/c6a.xlarge.json
+++ b/opengpdb/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1579,
     "data_size": 39978480949,
     "concurrent_qps": 0.027,

--- a/opengpdb/template.json
+++ b/opengpdb/template.json
@@ -7,6 +7,7 @@
     "C",
     "column-oriented",
     "PostgreSQL compatible",
-    "lukewarm-cold-run"
+    "lukewarm-cold-run",
+    "Greenplum derivative"
   ]
 }

--- a/warehousepg/results/20260516/c6a.4xlarge.json
+++ b/warehousepg/results/20260516/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1185,
     "data_size": 36104468292,
     "concurrent_qps": 0.188,

--- a/warehousepg/results/20260516/c6a.metal.json
+++ b/warehousepg/results/20260516/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 546,
     "data_size": 36407066192,
     "concurrent_qps": 2.073,

--- a/warehousepg/results/20260516/c7a.metal-48xl.json
+++ b/warehousepg/results/20260516/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 510,
     "data_size": 36387256636,
     "concurrent_qps": 2.823,

--- a/warehousepg/results/20260516/c8g.4xlarge.json
+++ b/warehousepg/results/20260516/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1197,
     "data_size": 36100305807,
     "concurrent_qps": 0.197,

--- a/warehousepg/results/20260516/c8g.metal-48xl.json
+++ b/warehousepg/results/20260516/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 553,
     "data_size": 36349239692,
     "concurrent_qps": 2.983,

--- a/warehousepg/results/20260517/c6a.2xlarge.json
+++ b/warehousepg/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1218,
     "data_size": 36364652026,
     "concurrent_qps": 0.077,

--- a/warehousepg/results/20260517/c6a.xlarge.json
+++ b/warehousepg/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run"],
+    "tags": ["C","column-oriented","PostgreSQL compatible","lukewarm-cold-run","Greenplum derivative"],
     "load_time": 1465,
     "data_size": 36322022880,
     "concurrent_qps": 0.025,

--- a/warehousepg/template.json
+++ b/warehousepg/template.json
@@ -7,6 +7,7 @@
     "C",
     "column-oriented",
     "PostgreSQL compatible",
-    "lukewarm-cold-run"
+    "lukewarm-cold-run",
+    "Greenplum derivative"
   ]
 }


### PR DESCRIPTION
## Summary
- Introduces a new tag, **\`Greenplum derivative\`**, and applies it to the five Greenplum-family forks: **Greenplum**, **Cloudberry**, **WarehousePG**, **Greengage**, **OpenGPDB**.
- Updates each system's \`template.json\` and every historical result file (49 files total: 5 templates + 44 results).
- Existing per-file JSON formatting is preserved: multi-line tag arrays stay multi-line with matching indent, single-line arrays stay single-line, and the comma-spacing style (\`,\` vs \`, \`) of each file is honored.

## Test plan
- [x] All 49 modified files re-parse as valid JSON.
- [x] Every modified file contains exactly one \`Greenplum derivative\` tag (no duplicates, no misses).
- [ ] Reviewer spot-checks formatting on the historical multi-line greenplum result (e.g. \`greenplum/results/20161221/historical-100m.json\`) and on the single-line recent ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)