### PR TITLE
Add "stateless" tag to Hive and Impala

### DIFF
--- a/hive/results/20130923/historical-100m.json
+++ b/hive/results/20130923/historical-100m.json
@@ -10,7 +10,8 @@
     "tags": [
         "Java",
         "MapReduce",
-        "historical"
+        "historical",
+        "stateless"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/hive/results/20130923/historical-10m.json
+++ b/hive/results/20130923/historical-10m.json
@@ -10,7 +10,8 @@
     "tags": [
         "Java",
         "MapReduce",
-        "historical"
+        "historical",
+        "stateless"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/hive/results/20260517/c6a.4xlarge.json
+++ b/hive/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["Java","MapReduce","Tez","stateless"],
+    "tags": ["Java","MapReduce","stateless"],
     "load_time": 9,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/hive/results/20260517/c6a.4xlarge.json
+++ b/hive/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["Java","MapReduce","Tez"],
+    "tags": ["Java","MapReduce","Tez","stateless"],
     "load_time": 9,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/hive/template.json
+++ b/hive/template.json
@@ -6,7 +6,6 @@
   "tags": [
     "Java",
     "MapReduce",
-    "Tez",
     "stateless"
   ]
 }

--- a/hive/template.json
+++ b/hive/template.json
@@ -6,6 +6,7 @@
   "tags": [
     "Java",
     "MapReduce",
-    "Tez"
+    "Tez",
+    "stateless"
   ]
 }

--- a/impala/results/20260517/c6a.2xlarge.json
+++ b/impala/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented"],
+    "tags": ["C++","MPP","column-oriented","stateless"],
     "load_time": 63,
     "data_size": 14779976446,
     "concurrent_qps": 0.23,

--- a/impala/results/20260517/c6a.4xlarge.json
+++ b/impala/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented"],
+    "tags": ["C++","MPP","column-oriented","stateless"],
     "load_time": 55,
     "data_size": 14779976446,
     "concurrent_qps": 0.498,

--- a/impala/results/20260517/c6a.metal.json
+++ b/impala/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented"],
+    "tags": ["C++","MPP","column-oriented","stateless"],
     "load_time": 51,
     "data_size": 14779976446,
     "concurrent_qps": 0.933,

--- a/impala/results/20260517/c6a.xlarge.json
+++ b/impala/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented"],
+    "tags": ["C++","MPP","column-oriented","stateless"],
     "load_time": 94,
     "data_size": 14779976446,
     "concurrent_qps": 0.113,

--- a/impala/results/20260517/c7a.metal-48xl.json
+++ b/impala/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented"],
+    "tags": ["C++","MPP","column-oriented","stateless"],
     "load_time": 46,
     "data_size": 14779976446,
     "concurrent_qps": 0.988,

--- a/impala/template.json
+++ b/impala/template.json
@@ -6,6 +6,7 @@
   "tags": [
     "C++",
     "MPP",
-    "column-oriented"
+    "column-oriented",
+    "stateless"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `stateless` tag to Hive and Impala templates and all existing result files.

## Test plan
- [x] `grep -L stateless` on all affected files returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)