### PR TITLE
Replace shell expansion with find to avoid ARG_MAX

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -12,7 +12,8 @@ FIRST=1
 
 # Build "<system>/<basename> <full-path>" lines, then keep the last (latest)
 # row per key — sorted ascending by date, since YYYYMMDD sorts lexically.
-LANG="" ls -1 */results/*/*.json \
+LANG="" find . -mindepth 4 -maxdepth 4 -type f -name '*.json' -path './*/results/*/*' \
+    | sed 's|^\./||' \
     | grep -Ev '^(hardware|versions|gravitons)/' \
     | sort \
     | awk -F/ '{ print $1"/"$NF" "$0 }' \


### PR DESCRIPTION
While workin on #933 , I hit this small issue, basically hitting ARG_MAX on the shell expansion. This replaces it with `find` to avoid shell expansion.

Likely only an issue on macOS, it doesn't happen when running against the EC2 server. So just a small QoL improvement.