### PR TITLE
fix(datafusion): Update docs, skip concurrent_qps, Skip re-downloading partitioned files

### DIFF
--- a/datafusion-partitioned/benchmark.sh
+++ b/datafusion-partitioned/benchmark.sh
@@ -3,4 +3,7 @@
 export BENCH_DOWNLOAD_SCRIPT="download-hits-parquet-partitioned"
 export BENCH_DURABLE=yes
 export BENCH_RESTARTABLE=no
+# skip concurrent_qps tests by default as datafusion-cli is configured
+# for single user/single process usage
+export BENCH_CONCURRENT_DURATION="${BENCH_CONCURRENT_DURATION:-0}"
 exec ../lib/benchmark-common.sh

--- a/datafusion-partitioned/load
+++ b/datafusion-partitioned/load
@@ -1,9 +1,14 @@
 #!/bin/bash
 # datafusion queries the parquet files via an external table at LOCATION
 # 'partitioned' (see create.sql). The shared bench_download fetches the
-# parquet files into CWD; move them into the expected subdir.
+# parquet files into CWD; link them into the expected subdir.
+#
+# Note: don't move them to avoid re-downloading each time
 set -e
 
 mkdir -p partitioned
-mv hits_*.parquet partitioned/ 2>/dev/null || true
+for f in hits_*.parquet; do
+    ln -s -f "../$f" "partitioned/$f"
+done
+
 sync

--- a/datafusion-partitioned/load
+++ b/datafusion-partitioned/load
@@ -1,14 +1,14 @@
 #!/bin/bash
 # datafusion queries the parquet files via an external table at LOCATION
 # 'partitioned' (see create.sql). The shared bench_download fetches the
-# parquet files into CWD; link them into the expected subdir.
+# parquet files into CWD; hard-link them into the expected subdir.
 #
 # Note: don't move them to avoid re-downloading each time
 set -e
 
 mkdir -p partitioned
 for f in hits_*.parquet; do
-    ln -s -f "../$f" "partitioned/$f"
+    ln -f "$f" "partitioned/$f"
 done
 
 sync

--- a/datafusion/README.md
+++ b/datafusion/README.md
@@ -25,7 +25,7 @@ All with no EBS optimization and no instance store.
 2. Wait for the status checks to pass, then ssh to EC2: `ssh ubuntu@{ip}`
 3. `git clone https://github.com/ClickHouse/ClickBench`
 4. `cd ClickBench/datafusion`
-5. `vi benchmark.sh` and modify the following line to target the DataFusion version
+5. `vi install` and modify the following line to target the DataFusion version
 
     ```bash
     git checkout 53.1.0

--- a/datafusion/benchmark.sh
+++ b/datafusion/benchmark.sh
@@ -3,4 +3,7 @@
 export BENCH_DOWNLOAD_SCRIPT="download-hits-parquet-single"
 export BENCH_DURABLE=yes
 export BENCH_RESTARTABLE=no
+# skip concurrent_qps tests by default as datafusion-cli is configured
+# for single user/single process usage
+export BENCH_CONCURRENT_DURATION="${BENCH_CONCURRENT_DURATION:-0}"
 exec ../lib/benchmark-common.sh


### PR DESCRIPTION
# Rationale

While trying to gather results for a new DataFusion release, I could not complete the benchmark scripts because the new concurrent QPS test caused the `bash benchmark.sh` run to be OOM-killed by the kernel.

I also hit two rough edges:

1. `datafusion-partitioned/benchmark.sh` now re-downloads the partitioned Parquet source files on each run, which makes it harder to iterate on the scripts locally.
2. The DataFusion documentation still referred to the old script layout.

# Changes

This PR addresses those issues and lets me run the DataFusion benchmarks again:

1. Disable the concurrent QPS test by default for DataFusion entries, since `datafusion-cli` is configured here for single-user/single-process benchmark runs.
2. Hard-link the partitioned Parquet files into the `partitioned/` directory instead of moving them, so reruns do not re-download the source files.
3. Update the DataFusion README to point to the new `install` script when changing the DataFusion version.

I plan to submit a separate PR with updated results once the DataFusion release is finalized.

# Question: should contributors still submit updated results?

It is not clear to me after the recent refactors whether you prefer contributors to run and submit benchmark results as part of release-update PRs, or whether you prefer to use the ClickBench automation to regenerate the numbers.

The DataFusion results were recently updated in:

- https://github.com/ClickHouse/ClickBench/pull/840
- https://github.com/ClickHouse/ClickBench/pull/844

The benchmark scripts were also substantially refactored in:

- https://github.com/ClickHouse/ClickBench/pull/860

Updating ClickBench results takes me several hours for each DataFusion release, and I would like to decrease that. I looked into using `./run-benchmark.sh`, which appears to be the automation entry point, but from an external contributor perspective:

1. It posts logs to the ClickHouse Play `sink` user, and I do not know how to retrieve the generated result JSON from that pipeline.
2. The supporting pieces appear to be in `prepare-database.sql` and `collect-results.sh`, but the setup for using them with a contributor-owned ClickHouse instance is not documented.

If contributors are expected to run the benchmarks themselves, it would be helpful to document the recommended end-to-end workflow for launching the machines and collecting the generated JSON files.
