### PR TITLE
Fix generate-results.sh: avoid "Argument list too long"

### DIFF
--- a/generate-results.sh
+++ b/generate-results.sh
@@ -12,7 +12,9 @@ FIRST=1
 
 # Build "<system>/<basename> <full-path>" lines, then keep the last (latest)
 # row per key — sorted ascending by date, since YYYYMMDD sorts lexically.
-LANG="" ls -1 */results/*/*.json \
+# Use `find` rather than `ls */results/*/*.json`: to avoid overflowing ARG_MAX
+# (clickhouse-cloud alone has tens of thousands of files)
+LANG="" find */results -mindepth 2 -maxdepth 2 -name '*.json' \
     | grep -Ev '^(hardware|versions|gravitons)/' \
     | sort \
     | awk -F/ '{ print $1"/"$NF" "$0 }' \


### PR DESCRIPTION
## Problem
While working on https://github.com/ClickHouse/ClickBench/pull/948 I hit a problem regenerating `data.generated.js`. Specifically, running  `bash generate-results.sh` fails locally with:

```
generate-results.sh: line 15: /bin/ls: Argument list too long
```

This is because `ls */results/*/*.json`, expands **every** result path onto a single command line which exceeds the shell's `ARG_MAX`. 

There are a huge number of files in this repo now (`clickhouse-cloud` alone has tens of thousands) so I don't know how the data.generated.js that is checked in was generated. 

## Fix

Use `find` to walk the tree instead of expanding a glob:

```sh
LANG="" find */results -mindepth 2 -maxdepth 2 -name '*.json'
```
