### PR TITLE
Fix and document the Tinybird benchmark runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ hits.vortex
 bemidb/bemidb
 bemidb/iceberg
 
-# Python venvs created by install scripts
+# Local credentials and Python virtual environments
 myenv
 .tinyb
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ bemidb/iceberg
 
 # Python venvs created by install scripts
 myenv
+.tinyb
+.venv/

--- a/tinybird/README.md
+++ b/tinybird/README.md
@@ -81,8 +81,7 @@ Alternatively, create a more restrictive token in the Tinybird UI with `PIPES:RE
 benchmark from this directory:
 
 ```bash
-set -o pipefail
-TINYBIRD_HOST="$(jq -r '.host' .tinyb)" \
+TINYBIRD_HOST="$(jq -er '.host | strings | select(length > 0)' .tinyb)" \
 TINYBIRD_TOKEN='<copied token>' \
-./run.sh 2>&1 | tee log.txt
+./run.sh > >(tee log.txt) 2>&1
 ```

--- a/tinybird/README.md
+++ b/tinybird/README.md
@@ -25,7 +25,8 @@ tb auth -i
 ```
 
 `tb auth -i` asks for the Tinybird region and an admin token. You can copy the admin token from the "Tokens" page in the Tinybird UI.
-The command writes credentials to a local `.tinyb` file, so do not commit that file.
+The command writes credentials and the selected workspace API host to a local `.tinyb` file. The file is ignored by Git because it must not
+be committed.
 
 # Inserting data
 
@@ -80,5 +81,8 @@ Alternatively, create a more restrictive token in the Tinybird UI with `PIPES:RE
 benchmark from this directory:
 
 ```bash
-TINYBIRD_TOKEN='<copied token>' ./run.sh 2>&1 | tee log.txt
+set -o pipefail
+TINYBIRD_HOST="$(jq -r '.host' .tinyb)" \
+TINYBIRD_TOKEN='<copied token>' \
+./run.sh 2>&1 | tee log.txt
 ```

--- a/tinybird/README.md
+++ b/tinybird/README.md
@@ -15,16 +15,39 @@ Load time and data size in the results are set to 0, as Tinybird did not indicat
 
 Head to https://www.tinybird.co and create an account.
 
+Install the Tinybird CLI and authenticate it against the workspace you want to use for the benchmark:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install tinybird-cli
+tb auth -i
+```
+
+`tb auth -i` asks for the Tinybird region and an admin token. You can copy the admin token from the "Tokens" page in the Tinybird UI.
+The command writes credentials to a local `.tinyb` file, so do not commit that file.
+
 # Inserting data
 
 Tinybird supports data inserts from various sources. We are going to use S3 to load a Parquet file into Tinybird. Since Tinybird limits the
 file size to 1 GB, and the test data set is larger than that, we split it into smaller chunks using ClickHouse:
 
-```sql
-INSERT INTO FUNCTION s3('https://hitsparquet.s3.eu-west-3.amazonaws.com/data/hits_{_partition_id}.parquet', '', '', 'Parquet')
+```bash
+clickhouse-client --query "
+INSERT INTO FUNCTION s3(
+    'https://<bucket>.s3.<region>.amazonaws.com/<prefix>/hits_{_partition_id}.parquet',
+    '<aws_access_key_id>',
+    '<aws_secret_access_key>',
+    'Parquet'
+)
 PARTITION BY rand() % 50
 SELECT * FROM hits
+"
 ```
+
+Run this from a ClickHouse instance where the ClickBench `hits` table has already been loaded. Replace the S3 URL and credentials with a
+bucket/prefix that Tinybird can read. After the `INSERT` finishes, create a Tinybird Data Source named `hits` from the generated
+`hits_*.parquet` files, choose Parquet as the format, and use auto mode so all files in the prefix are imported.
 
 Importing files with sizes a little bit less than 1 GB did not always work. We instead used 50 files of around 280 MB each. You will need to
 use the auto mode to make sure all the files are read.
@@ -32,4 +55,30 @@ use the auto mode to make sure all the files are read.
 # Querying the data
 
 Once the data is inserted you can create the endpoints needed to run the benchmark using pipes. `run.sh` will iterate through each endpoint.
-Set `TINYBIRD_TOKEN` to a Tinybird token with read access before running the script.
+
+Create one Tinybird Pipe endpoint for each query in `clickhouse/queries.sql`. The endpoint names must be `Q1`, `Q2`, ..., `Q43`, because
+`run.sh` calls `/v0/pipes/Q${i}.json`. You can create them in the UI, or generate them with the CLI from this directory:
+
+```bash
+i=1
+while IFS= read -r query; do
+    tb pipe generate "Q${i}" "$query" --force
+    i=$((i + 1))
+done < ../clickhouse/queries.sql
+
+tb push pipes/*.pipe
+```
+
+Create and copy a token for the benchmark runner. In a dedicated benchmark workspace, the simplest CLI command is:
+
+```bash
+tb token create static clickbench_read --scope WORKSPACE:READ_ALL
+tb token copy clickbench_read
+```
+
+Alternatively, create a more restrictive token in the Tinybird UI with `PIPES:READ` access to the `Q1` through `Q43` pipes. Then run the
+benchmark from this directory:
+
+```bash
+TINYBIRD_TOKEN='<copied token>' ./run.sh 2>&1 | tee log.txt
+```

--- a/tinybird/README.md
+++ b/tinybird/README.md
@@ -32,3 +32,4 @@ use the auto mode to make sure all the files are read.
 # Querying the data
 
 Once the data is inserted you can create the endpoints needed to run the benchmark using pipes. `run.sh` will iterate through each endpoint.
+Set `TINYBIRD_TOKEN` to a Tinybird token with read access before running the script.

--- a/tinybird/run.sh
+++ b/tinybird/run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-BASE_URL="https://api.tinybird.co/v0/pipes/"
 : "${TINYBIRD_TOKEN:?Set TINYBIRD_TOKEN}"
+: "${TINYBIRD_HOST:?Set TINYBIRD_HOST to your workspace API host}"
+BASE_URL="${TINYBIRD_HOST%/}/v0/pipes/"
 AUTH_HEADER="Authorization: Bearer ${TINYBIRD_TOKEN}"
 
 results="["

--- a/tinybird/run.sh
+++ b/tinybird/run.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 
-# Define the base URL and Authorization token
 BASE_URL="https://api.tinybird.co/v0/pipes/"
-AUTH_HEADER=<TOKEN>
+: "${TINYBIRD_TOKEN:?Set TINYBIRD_TOKEN}"
+AUTH_HEADER="Authorization: Bearer ${TINYBIRD_TOKEN}"
 
 results="["
 
 for i in {1..43}; do
     times=()
     for j in {1..3}; do
-        response=$(curl -s --compressed -H "$AUTH_HEADER" "${BASE_URL}Q${i}.json")
-
-        elapsed=$(echo "$response" | jq '.statistics.elapsed')
-        echo "$elapsed"
-        times+=($elapsed)
+        response=$(curl -fsS --compressed -H "$AUTH_HEADER" "${BASE_URL}Q${i}.json")
+        elapsed=$(jq -er '.statistics.elapsed | numbers' <<< "$response")
+        times+=("$elapsed")
     done
     results+=$(printf "[%s,%s,%s]," "${times[0]}" "${times[1]}" "${times[2]}")
 done


### PR DESCRIPTION
## Summary

- replace the invalid placeholder authorization header with required `TINYBIRD_TOKEN` and `TINYBIRD_HOST` environment variables
- fail on shell, HTTP, malformed JSON, and non-numeric timing errors
- document the Tinybird CLI setup, data import, pipe generation, token creation, and benchmark invocation
- use the host selected by `tb auth -i`, preserve runner failures when logging with `tee`, and ignore local credentials and virtual environments

## Why

`AUTH_HEADER=<TOKEN>` is parsed as shell redirection, so the runner exits before sending any benchmark requests. The previous instructions also did not cover the setup needed to create the 43 pipe endpoints and run the benchmark.

## Validation

- `bash -n tinybird/run.sh`
- verified missing token and host values fail before any request
- mocked successful Tinybird responses and verified the output contains 43 arrays with three numeric timings each
- verified malformed and non-numeric timing responses fail
- `git diff --check`