### PR TITLE
Flag lukewarm cold runs and account for them in the Combined metric

### DIFF
--- a/alloydb/results/20231125/gcp.128GB_tuned.json
+++ b/alloydb/results/20231125/gcp.128GB_tuned.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible", "managed", "gcp"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "managed", "gcp", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 9941379875,

--- a/alloydb/results/20231125/gcp.64GB.json
+++ b/alloydb/results/20231125/gcp.64GB.json
@@ -12,7 +12,8 @@
         "column-oriented",
         "PostgreSQL compatible",
         "managed",
-        "gcp"
+        "gcp",
+        "lukewarm-cold-run"
     ],
     "load_time": 1543,
     "data_size": 9941379875,

--- a/alloydb/results/20231125/gcp.64GB_tuned.json
+++ b/alloydb/results/20231125/gcp.64GB_tuned.json
@@ -8,7 +8,7 @@
     "tuned": "yes",
     "comment": "",
 
-    "tags": ["C", "column-oriented", "PostgreSQL compatible", "managed", "gcp"],
+    "tags": ["C", "column-oriented", "PostgreSQL compatible", "managed", "gcp", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 9941379875,

--- a/athena-partitioned/results/20220701/serverless.json
+++ b/athena-partitioned/results/20220701/serverless.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["stateless", "managed", "Java", "column-oriented", "aws"],
+    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 13800000000,

--- a/athena/results/20220701/serverless.json
+++ b/athena/results/20220701/serverless.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "historical"],
+    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "historical", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 13800000000,

--- a/aurora-mysql/results/20220701/16acu.json
+++ b/aurora-mysql/results/20220701/16acu.json
@@ -12,7 +12,8 @@
         "C++",
         "MySQL compatible",
         "row-oriented",
-        "aws"
+        "aws",
+        "lukewarm-cold-run"
     ],
     "load_time": 7687,
     "data_size": 89614492631,

--- a/aurora-postgresql/results/20220701/16acu.json
+++ b/aurora-postgresql/results/20220701/16acu.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "C", "PostgreSQL compatible", "row-oriented", "aws"],
+    "tags": ["managed", "C", "PostgreSQL compatible", "row-oriented", "aws", "lukewarm-cold-run"],
 
     "load_time": 2127,
     "data_size": 52183852646,

--- a/bigquery/results/20251028/result.json
+++ b/bigquery/results/20251028/result.json
@@ -10,7 +10,8 @@
         "serverless",
         "column-oriented",
         "gcp",
-        "managed"
+        "managed",
+        "lukewarm-cold-run"
     ],
     "load_time": 777,
     "data_size": 8760000000,

--- a/bytehouse/results/20220727/l.json
+++ b/bytehouse/results/20220727/l.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/m.json
+++ b/bytehouse/results/20220727/m.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/s.json
+++ b/bytehouse/results/20220727/s.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/xs.json
+++ b/bytehouse/results/20220727/xs.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/chyt/results/20240916/yt.360GB_YC.json
+++ b/chyt/results/20240916/yt.360GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.48GB_YC.json
+++ b/chyt/results/20240916/yt.48GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.720GB_YC.json
+++ b/chyt/results/20240916/yt.720GB_YC.json
@@ -10,7 +10,8 @@
         "ClickHouse derivative",
         "managed",
         "YT",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.96GB_YC.json
+++ b/chyt/results/20240916/yt.96GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/clickhouse-cloud/collect-results.sh
+++ b/clickhouse-cloud/collect-results.sh
@@ -41,7 +41,7 @@ do
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "'$PROVIDER'"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "'$PROVIDER'", "lukewarm-cold-run"],
 
     "load_time": '$LOAD_TIME',
     "data_size": '$DATA_SIZE',

--- a/crunchy-bridge-for-analytics/results/20240605/crunchy-bridge-analytics-256.json
+++ b/crunchy-bridge-for-analytics/results/20240605/crunchy-bridge-analytics-256.json
@@ -7,7 +7,7 @@
     "hardware": "cpu",
     "tuned": "no",
     "comment":"",
-    "tags": ["column-oriented","DuckDB derivative", "PostgreSQL compatible", "managed"],
+    "tags": ["column-oriented","DuckDB derivative", "PostgreSQL compatible", "managed", "lukewarm-cold-run"],
     "load_time": 0,
     "data_size": 14779976446,
 

--- a/databricks/benchmark.py
+++ b/databricks/benchmark.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
         "cluster_size": "<Lookup here: https://docs.databricks.com/aws/en/compute/sql-warehouse/warehouse-behavior>",
         "proprietary": "yes",
         "tuned": "no",
-        "tags": ["managed", "column-oriented"],
+        "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
     }
 
     load_data(run_metadata)

--- a/databricks/results/20251110/2x-small.json
+++ b/databricks/results/20251110/2x-small.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 90,
     "data_size": 10219802927,

--- a/databricks/results/20251113/2x-large.json
+++ b/databricks/results/20251113/2x-large.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 36,
     "data_size": 10219802927,

--- a/databricks/results/20251113/4x-large.json
+++ b/databricks/results/20251113/4x-large.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 30,
     "data_size": 10219802927,

--- a/databricks/results/20251113/large.json
+++ b/databricks/results/20251113/large.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 45,
     "data_size": 10219802927,

--- a/databricks/results/20251113/medium.json
+++ b/databricks/results/20251113/medium.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 53,
     "data_size": 10219802927,

--- a/databricks/results/20251113/small.json
+++ b/databricks/results/20251113/small.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 67,
     "data_size": 10219802927,

--- a/databricks/results/20251113/x-large.json
+++ b/databricks/results/20251113/x-large.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 41,
     "data_size": 10219802927,

--- a/databricks/results/20251113/x-small.json
+++ b/databricks/results/20251113/x-small.json
@@ -8,7 +8,8 @@
     "tuned": "no",
     "tags": [
         "managed",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 91,
     "data_size": 10219802927,

--- a/firebolt/results/20250607/medium.json
+++ b/firebolt/results/20250607/medium.json
@@ -8,7 +8,8 @@
         "C++",
         "column-oriented",
         "ClickHouse derivative",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 0,
     "data_size": 14730000000,

--- a/firebolt/results/20250607/small.json
+++ b/firebolt/results/20250607/small.json
@@ -8,7 +8,8 @@
         "C++",
         "column-oriented",
         "ClickHouse derivative",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 0,
     "data_size": 14730000000,

--- a/firebolt/results/20260517/c6a.2xlarge.json
+++ b/firebolt/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 285,
     "data_size": 15827354954,
     "concurrent_qps": 0.375,

--- a/firebolt/results/20260517/c6a.4xlarge.json
+++ b/firebolt/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 235,
     "data_size": 15825985134,
     "concurrent_qps": 1.908,

--- a/firebolt/results/20260517/c6a.large.json
+++ b/firebolt/results/20260517/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 488,
     "data_size": 15816235785,
     "concurrent_qps": 0.262,

--- a/firebolt/results/20260517/c6a.metal.json
+++ b/firebolt/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 172,
     "data_size": 15823268468,
     "concurrent_qps": 9.84,

--- a/firebolt/results/20260517/c6a.xlarge.json
+++ b/firebolt/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 330,
     "data_size": 15827881790,
     "concurrent_qps": 0.2,

--- a/firebolt/results/20260517/c7a.metal-48xl.json
+++ b/firebolt/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 197,
     "data_size": 15826419844,
     "concurrent_qps": 18.902,

--- a/firebolt/results/20260517/c8g.4xlarge.json
+++ b/firebolt/results/20260517/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 241,
     "data_size": 15827812385,
     "concurrent_qps": 3.773,

--- a/firebolt/results/20260517/c8g.metal-48xl.json
+++ b/firebolt/results/20260517/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative", "lukewarm-cold-run"],
     "load_time": 175,
     "data_size": 15825383440,
     "concurrent_qps": 19.565,

--- a/firebolt/template.json
+++ b/firebolt/template.json
@@ -7,6 +7,7 @@
     "C++",
     "column-oriented",
     "PostgreSQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "lukewarm-cold-run"
   ]
 }

--- a/hologres/results/20250521/128core.json
+++ b/hologres/results/20250521/128core.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed"],
+    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed", "lukewarm-cold-run"],
     "load_time": 321,
     "data_size": 19923251230,
     "result": [

--- a/hologres/results/20250521/32core.json
+++ b/hologres/results/20250521/32core.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed"],
+    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed", "lukewarm-cold-run"],
     "load_time": 388,
     "data_size": 18778181002,
     "result": [

--- a/hologres/results/20250521/64core.json
+++ b/hologres/results/20250521/64core.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed"],
+    "tags": ["managed", "PostgreSQL compatible", "column-oriented", "managed", "lukewarm-cold-run"],
     "load_time": 366,
     "data_size": 19708639814,
     "result": [

--- a/hydra/results/20230919/c6a.4xlarge.json
+++ b/hydra/results/20230919/c6a.4xlarge.json
@@ -6,7 +6,8 @@
     "comment": "",
     "tags": [
         "PostgreSQL compatible",
-        "column-oriented"
+        "column-oriented",
+        "lukewarm-cold-run"
     ],
     "load_time": 1222,
     "data_size": 18995669982,

--- a/impala/results/20260517/c6a.2xlarge.json
+++ b/impala/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 63,
     "data_size": 14779976446,
     "concurrent_qps": 0.23,

--- a/impala/results/20260517/c6a.4xlarge.json
+++ b/impala/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 55,
     "data_size": 14779976446,
     "concurrent_qps": 0.498,

--- a/impala/results/20260517/c6a.metal.json
+++ b/impala/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 51,
     "data_size": 14779976446,
     "concurrent_qps": 0.933,

--- a/impala/results/20260517/c6a.xlarge.json
+++ b/impala/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 94,
     "data_size": 14779976446,
     "concurrent_qps": 0.113,

--- a/impala/results/20260517/c7a.metal-48xl.json
+++ b/impala/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless", "lukewarm-cold-run"],
     "load_time": 46,
     "data_size": 14779976446,
     "concurrent_qps": 0.988,

--- a/impala/template.json
+++ b/impala/template.json
@@ -7,6 +7,7 @@
     "C++",
     "MPP",
     "column-oriented",
-    "stateless"
+    "stateless",
+    "lukewarm-cold-run"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1086,8 +1086,26 @@ function renderSummary(filtered_data) {
 
         const text = selectors.metric == 'load' ? (elem.load_time ? `${Math.round(elem.load_time)}s (×${ratio.toFixed(2)})` : 'stateless')
             :  selectors.metric == 'size' ? `${(elem.data_size / 1024 / 1024 / 1024).toFixed(2)} GiB (×${ratio.toFixed(2)})`
+            :  selectors.metric == 'combined' ? (() => {
+                    /// Break the combined score into the components it's built
+                    /// from (hot, cold, load, storage) as the relative "×N"
+                    /// ratios that feed the weighted score. Pad each to a fixed
+                    /// width so the columns line up in the monospace cell.
+                    const fmt = (v, n) => ((v == null || !isFinite(v)) ? 'n/a' : `×${v.toFixed(2)}`).padStart(n, ' ');
+                    const hot = fmt(relativeQueryTime(num_queries, baseline_data, elem, 'hot'), 6);
+                    const cold = fmt(metricExcludes(elem, 'cold') ? null : relativeQueryTime(num_queries, baseline_data, elem, 'cold'), 6);
+                    const load = fmt(metricExcludes(elem, 'load') ? null : elem.load_time / min_load_time, 6);
+                    const size = fmt(metricExcludes(elem, 'size') ? null : elem.data_size / min_data_size, 5);
+                    return `  (hot ${hot}, cold ${cold}, load ${load}, storage ${size})`;
+                })()
             : `×${ratio.toFixed(2)}`;
 
+        // Combined shows a bold overall score followed by the (plain) breakdown.
+        if (selectors.metric == 'combined') {
+            let score = document.createElement('strong');
+            score.appendChild(document.createTextNode(`×${ratio.toFixed(2)}`));
+            td_number.appendChild(score);
+        }
         td_number.appendChild(document.createTextNode(text));
 
         let td_bar = document.createElement('td');

--- a/index.html
+++ b/index.html
@@ -926,6 +926,33 @@ function nameToColor(str) {
     return 60 + Math.abs(x % 240);
 }
 
+/// Whether a system is excluded from a given metric. Single source of truth
+/// shared by the top-level metric filter (render) and the per-run baseline
+/// used inside the Combined metric (renderSummary) so the two never drift.
+function metricExcludes(elem, metric) {
+    const tags = elem.tags || [];
+    switch (metric) {
+        case 'size':
+            /// Can't rank a system that didn't report a data size.
+            return !(elem.data_size > 1e9);
+        case 'load':
+            /// Needs a real load step: skip trivially-fast loads and
+            /// stateless / in-memory engines that don't persist data.
+            return !(elem.load_time >= 5) || tags.includes('stateless') || tags.includes('in-memory');
+        case 'cold':
+            /// True cold-cache reads only: in-memory engines have nothing to
+            /// read from storage, and lukewarm runs never flush engine caches.
+            return tags.includes('in-memory') || tags.includes('lukewarm-cold-run');
+        case 'combined':
+            /// Combined still scores lukewarm systems (with the cold component
+            /// dropped, see below), but in-memory engines are excluded.
+            return tags.includes('in-memory');
+        case 'hot':
+        default:
+            return false;
+    }
+}
+
 function renderSummary(filtered_data) {
     let table = document.getElementById('summary');
     clearElement(table);
@@ -941,10 +968,18 @@ function renderSummary(filtered_data) {
 
     const baseline_data = [...filtered_data[0].result.keys()].map(query_num =>
         [...Array(3).keys()].map(run_num =>
-            Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num]?.[run_num]).filter(x => x != null))));
+            Math.min(...filtered_data.filter(elem => !elem.fake)
+                // Apply the same per-metric exclusions to the baseline that the
+                // standalone metric uses: run 0 is the cold run, runs 1/2 are
+                // hot. This keeps lukewarm/in-memory systems out of the cold
+                // baseline so they can't depress the per-query minimum and
+                // inflate every true-cold system's cold ratio in Combined. In
+                // the standalone Cold Run metric they're already filtered out.
+                .filter(elem => !metricExcludes(elem, run_num === 0 ? 'cold' : 'hot'))
+                .map(elem => elem.result[query_num]?.[run_num]).filter(x => x != null))));
 
-    const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x && x > 5));
-    const min_data_size = Math.min(...filtered_data.map(elem => elem.data_size).filter(x => x && x > 1e9));
+    const min_load_time = Math.min(...filtered_data.filter(elem => !metricExcludes(elem, 'load')).map(elem => elem.load_time));
+    const min_data_size = Math.min(...filtered_data.filter(elem => !metricExcludes(elem, 'size')).map(elem => elem.data_size));
 
     let summaries;
     if (selectors.metric == 'load') {
@@ -957,11 +992,39 @@ function renderSummary(filtered_data) {
         summaries = filtered_data.map(elem => relativeQueryTime(num_queries, baseline_data, elem, selectors.metric));
         document.getElementById('time-or-size').innerText = 'time';
     } else if (selectors.metric == 'combined') {
-        summaries = filtered_data.map(elem => Math.exp(
-            combined_load_time_share * Math.log(elem.load_time >= 5 ? (elem.load_time / min_load_time) : 1) +
-            combined_data_size_share * Math.log(elem.data_size >= 1e9 ? (elem.data_size / min_data_size) : 2) +
-            combined_cold_share * Math.log(relativeQueryTime(num_queries, baseline_data, elem, 'cold')) +
-            combined_hot_share * Math.log(relativeQueryTime(num_queries, baseline_data, elem, 'hot'))));
+        summaries = filtered_data.map(elem => {
+            // Exclude metrics that are not applicable to this system from the combined score,
+            // and reweight the rest so the final score is still on a similar scale. For example,
+            // lukewarm systems that don't have a true cold run get their cold weight folded
+            // into hot, so they can still be compared against true cold systems on the hot
+            // performance they do have without being penalized for the cold performance they
+            // can't have.
+            const exclude_cold = metricExcludes(elem, 'cold');
+            const exclude_load = metricExcludes(elem, 'load');
+            const exclude_size = metricExcludes(elem, 'size');
+
+            const hot_share = exclude_cold ? combined_cold_share + combined_hot_share : combined_hot_share;
+            let log_sum = hot_share * Math.log(relativeQueryTime(num_queries, baseline_data, elem, 'hot'));
+
+            if (!exclude_cold) {
+                log_sum += combined_cold_share * Math.log(relativeQueryTime(num_queries, baseline_data, elem, 'cold'));
+            }
+
+            if (!exclude_load) {
+                log_sum += combined_load_time_share * Math.log(elem.load_time / min_load_time);
+            }
+
+            if (!exclude_size) {
+                log_sum += combined_data_size_share * Math.log(elem.data_size / min_data_size);
+            }
+
+            if (exclude_load || exclude_size) {
+                const correction = 1 - (exclude_load ? combined_load_time_share : 0) - (exclude_size ? combined_data_size_share : 0);
+                log_sum = log_sum / correction;
+            }
+
+            return Math.exp(log_sum);
+        });
         document.getElementById('time-or-size').innerText = 'time and data size';
     }
 
@@ -1130,16 +1193,9 @@ function render() {
         ((selectors.hardware.cpu && (elem.hardware === "cpu" || !elem.hardware)) || (selectors.hardware.gpu && elem.hardware === "gpu"))
         );
 
-    /// Filter out unreasonable entries
-    if (selectors.metric == 'size') {
-        filtered_data = filtered_data.filter(elem => elem.data_size);
-    }
-    if (selectors.metric == 'load') {
-        filtered_data = filtered_data.filter(elem => elem.load_time >= 5 && !elem.tags.includes('stateless'));
-    }
-    if (selectors.metric == 'cold' || selectors.metric == 'combined' || selectors.metric == 'load') {
-        filtered_data = filtered_data.filter(elem => !elem.tags.includes('in-memory'));
-    }
+    /// Filter out entries that can't be ranked under the selected metric
+    /// (see metricExcludes for the per-metric rules).
+    filtered_data = filtered_data.filter(elem => !metricExcludes(elem, selectors.metric));
 
     let nothing_selected_elem = document.getElementById('nothing-selected');
     if (filtered_data.length == 0) {

--- a/motherduck/benchmark.py
+++ b/motherduck/benchmark.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
         "proprietary": "yes",
         "hardware": "cpu",
         "tuned": "no",
-        "tags": ["C++", "column-oriented", "serverless", "managed"],
+        "tags": ["C++", "column-oriented", "serverless", "managed", "lukewarm-cold-run"],
     }
     load_data(run_metadata)
 

--- a/motherduck/results/20250304/result_jumbo.json
+++ b/motherduck/results/20250304/result_jumbo.json
@@ -8,7 +8,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 69,
     "data_size": 23620000000,

--- a/motherduck/results/20250304/result_pulse.json
+++ b/motherduck/results/20250304/result_pulse.json
@@ -8,7 +8,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 756,
     "data_size": 23620000000,

--- a/motherduck/results/20250304/result_standard.json
+++ b/motherduck/results/20250304/result_standard.json
@@ -8,7 +8,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 77,
     "data_size": 23620000000,

--- a/motherduck/results/20251019/pulse.json
+++ b/motherduck/results/20251019/pulse.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "managed"
+        "managed",
+        "lukewarm-cold-run"
     ],
     "load_time": 633,
     "data_size": 23622320128,

--- a/motherduck/results/20251019/standard.json
+++ b/motherduck/results/20251019/standard.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "managed"
+        "managed",
+        "lukewarm-cold-run"
     ],
     "load_time": 181,
     "data_size": 23622320128,

--- a/motherduck/results/20251022/jumbo.json
+++ b/motherduck/results/20251022/jumbo.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "managed"
+        "managed",
+        "lukewarm-cold-run"
     ],
     "load_time": 76,
     "data_size": 23622320128,

--- a/motherduck/results/20251022/mega.json
+++ b/motherduck/results/20251022/mega.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "DuckDB derivative",
         "serverless",
-        "managed"
+        "managed",
+        "lukewarm-cold-run"
     ],
     "load_time": 61,
     "data_size": 23622320128,

--- a/redshift-serverless/results/20220729/serverless.json
+++ b/redshift-serverless/results/20220729/serverless.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "lukewarm-cold-run"],
 
   "load_time": 1889,
   "data_size": 30300000000,

--- a/redshift/results/20220725/4x.ra3.16xlarge.json
+++ b/redshift/results/20220725/4x.ra3.16xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "lukewarm-cold-run"],
 
   "load_time": 1829,
   "data_size": 26330791936,

--- a/redshift/results/20220725/4x.ra3.4xlarge.json
+++ b/redshift/results/20220725/4x.ra3.4xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "lukewarm-cold-run"],
 
   "load_time": 1904,
   "data_size": 22313697280,

--- a/redshift/results/20220729/4x.ra3.xplus.json
+++ b/redshift/results/20220729/4x.ra3.xplus.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "lukewarm-cold-run"],
 
   "load_time": 2103,
   "data_size": 21060648960,

--- a/redshift/results/20230316/2x.dc2.8xlarge.json
+++ b/redshift/results/20230316/2x.dc2.8xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "lukewarm-cold-run"],
 
   "load_time": 2485,
   "data_size": 27278704640,

--- a/singlestore/results/20150405/historical-10m.json
+++ b/singlestore/results/20150405/historical-10m.json
@@ -10,7 +10,8 @@
     "tags": [
         "column-oriented",
         "MySQL compatible",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/singlestore/results/20220701/c6a.4xlarge.json
+++ b/singlestore/results/20220701/c6a.4xlarge.json
@@ -8,7 +8,7 @@
     "tuned": "yes",
     "comment": "Previous name: MemSQL. Some queries did not run due to memory limits",
 
-    "tags": ["MySQL compatible", "column-oriented"],
+    "tags": ["MySQL compatible", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 690,
     "data_size": 29836263469,

--- a/singlestore/results/20220715/s2.json
+++ b/singlestore/results/20220715/s2.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "Previous name: MemSQL. Some queries did not run due to unsupported regex",
 
-    "tags": ["MySQL compatible", "column-oriented", "managed"],
+    "tags": ["MySQL compatible", "column-oriented", "managed", "lukewarm-cold-run"],
 
     "load_time": 1145,
     "data_size": 19219978649,

--- a/singlestore/results/20220715/s24.json
+++ b/singlestore/results/20220715/s24.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "Previous name: MemSQL. Some queries did not run due to unsupported regex",
 
-    "tags": ["MySQL compatible", "column-oriented", "managed"],
+    "tags": ["MySQL compatible", "column-oriented", "managed", "lukewarm-cold-run"],
 
     "load_time": 1043,
     "data_size": 19219978649,

--- a/snowflake/results/20220701/2xl.json
+++ b/snowflake/results/20220701/2xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/3xl.json
+++ b/snowflake/results/20220701/3xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/4xl.json
+++ b/snowflake/results/20220701/4xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/l.json
+++ b/snowflake/results/20220701/l.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/m.json
+++ b/snowflake/results/20220701/m.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/s.json
+++ b/snowflake/results/20220701/s.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/xl.json
+++ b/snowflake/results/20220701/xl.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/xs.json
+++ b/snowflake/results/20220701/xs.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20260213/xs_interactive.json
+++ b/snowflake/results/20260213/xs_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "lukewarm-cold-run"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/tablespace/results/20240225/large-1-tuned.json
+++ b/tablespace/results/20240225/large-1-tuned.json
@@ -12,7 +12,8 @@
         "column-oriented",
         "PostgreSQL compatible",
         "managed",
-        "historical"
+        "historical",
+        "lukewarm-cold-run"
     ],
     "load_time": 13711,
     "data_size": 135469176422,

--- a/tablespace/results/20240225/large-1.json
+++ b/tablespace/results/20240225/large-1.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["Rust", "column-oriented", "PostgreSQL compatible", "managed"],
+  "tags": ["Rust", "column-oriented", "PostgreSQL compatible", "managed", "lukewarm-cold-run"],
 
   "load_time": 13711,
   "data_size": 135469176422,

--- a/timescale-cloud/results/20251213/16cpu.json
+++ b/timescale-cloud/results/20251213/16cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "64GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "lukewarm-cold-run"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251213/4cpu.json
+++ b/timescale-cloud/results/20251213/4cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "16GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "lukewarm-cold-run"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251213/8cpu.json
+++ b/timescale-cloud/results/20251213/8cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "32GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "lukewarm-cold-run"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/tinybird/results/20241111/tinybird.json
+++ b/tinybird/results/20241111/tinybird.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "lukewarm-cold-run"],
 
     "load_time": 0,
     "data_size": null,


### PR DESCRIPTION
ClickBench's "cold run" is only meaningful when the data is actually read back from the storage device, i.e., the engine is restarted (or never persists between queries) **and** the OS page cache is dropped before the first run. Systems that instead run an unseen query against a still-warm engine, or managed/remote services whose caches can't be flushed at all, do a *lukewarm* run and are supposed to carry the `lukewarm-cold-run` tag.

A number of such systems were never tagged, which lets their warm "cold" numbers compete directly with genuinely cold systems, distorting the combined ranking. This PR flags them and reworks how the Combined metric treats lukewarm (and otherwise inapplicable) components.

## Changes (3 commits)

### 1. `flag lukewarm cold runs`
Adds `lukewarm-cold-run` to systems that do not perform a true cold run:
- **Persistent local daemons never restarted between queries** (only the page cache is dropped, engine-internal caches survive): `impala`,  `firebolt`.
- **Managed/remote services** that can't be restarted or cache-flushed: clickhouse-cloud, motherduck, databricks, snowflake, redshift(+serverless), bigquery, athena(+partitioned), aurora-mysql, aurora-postgresql, alloydb, hologres, supabase, tablespace, tembo-olap, chyt, bytehouse, crunchy-bridge-for-analytics, timescale-cloud, tinybird, singlestore, hydra.

### 2. `reweight the combined metric for lukewarm and inapplicable metrics`
Unifies the per-metric exclusion rules in one `metricExcludes()` helper
(stateless→load, in-memory→cold/combined/load, lukewarm→cold, missing data
size→size) and reuses it everywhere:
- **Cold Run** ranking excludes lukewarm systems by default.
- The Combined per-query **cold baseline** excludes lukewarm/in-memory systems, so their warm "cold" numbers can't depress the baseline and inflate every true-cold system's cold ratio. `min` load time / data size likewise skip non-qualifying systems.
- A metric that doesn't apply to a system is **dropped, and the remaining weights renormalized** rather than fed a bogus ratio. Lukewarm systems keep a cold weight of 0 folded into hot (load 10% / size 10% / hot 80%).

### 3. `show individual hot/cold/load/storage ratios in the combined view`
Expands the Combined score cell to also list the four component ratios that feed it (`hot`, `cold`, `load`, `storage`), each as the relative `×N` ratio (`n/a` when a component doesn't apply).

<img width="3561" height="1168" alt="FireShot Capture 060 - ClickBench — a Benchmark For Analytical DBMS - " src="https://github.com/user-attachments/assets/883f71de-6e0e-4cfd-82a7-db9533651988" />

