### PR TITLE
Read EventDate parquet column directly as DATE in Trino

### DIFF
--- a/trino-datalake-partitioned/create.sql
+++ b/trino-datalake-partitioned/create.sql
@@ -8,7 +8,7 @@ CREATE TABLE hive.clickbench.hits_raw (
     Title varchar,
     GoodEvent smallint,
     EventTime bigint,
-    EventDate integer,
+    EventDate date,
     CounterID integer,
     ClientIP integer,
     RegionID integer,
@@ -114,14 +114,14 @@ WITH (
     format = 'PARQUET'
 );
 
--- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT)
--- and EventDate as days since 1970-01-01 (UINT16). Wrap the raw table in a view that exposes
--- the standard ClickBench types so the queries below need no further adaptation.
+-- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT).
+-- Wrap the raw table in a view that converts those columns to TIMESTAMP so the queries below need
+-- no further adaptation.
 CREATE VIEW hive.clickbench.hits AS
 SELECT
     WatchID, JavaEnable, Title, GoodEvent,
     from_unixtime(EventTime) AS EventTime,
-    date_add('day', EventDate, DATE '1970-01-01') AS EventDate,
+    EventDate,
     CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent,
     URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID,
     URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight,

--- a/trino-datalake/create.sql
+++ b/trino-datalake/create.sql
@@ -8,7 +8,7 @@ CREATE TABLE hive.clickbench.hits_raw (
     Title varchar,
     GoodEvent smallint,
     EventTime bigint,
-    EventDate integer,
+    EventDate date,
     CounterID integer,
     ClientIP integer,
     RegionID integer,
@@ -114,14 +114,14 @@ WITH (
     format = 'PARQUET'
 );
 
--- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT)
--- and EventDate as days since 1970-01-01 (UINT16). Wrap the raw table in a view that exposes
--- the standard ClickBench types so the queries below need no further adaptation.
+-- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT).
+-- Wrap the raw table in a view that converts those columns to TIMESTAMP so the queries below need
+-- no further adaptation.
 CREATE VIEW hive.clickbench.hits AS
 SELECT
     WatchID, JavaEnable, Title, GoodEvent,
     from_unixtime(EventTime) AS EventTime,
-    date_add('day', EventDate, DATE '1970-01-01') AS EventDate,
+    EventDate,
     CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent,
     URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID,
     URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight,

--- a/trino-partitioned/create.sql
+++ b/trino-partitioned/create.sql
@@ -6,7 +6,7 @@ CREATE TABLE hive.clickbench.hits_raw (
     Title varchar,
     GoodEvent smallint,
     EventTime bigint,
-    EventDate integer,
+    EventDate date,
     CounterID integer,
     ClientIP integer,
     RegionID integer,
@@ -112,14 +112,13 @@ WITH (
     format = 'PARQUET'
 );
 
--- The Parquet files store EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds
--- and EventDate as a UINT16 day-count from 1970-01-01. The view exposes the canonical
--- ClickBench column types so queries.sql matches the standard text.
+-- The Parquet files store EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds.
+-- The view converts those columns to TIMESTAMP so queries.sql matches the standard text.
 CREATE VIEW hive.clickbench.hits AS
 SELECT
     WatchID, JavaEnable, Title, GoodEvent,
     from_unixtime(EventTime) AS EventTime,
-    date_add('day', EventDate, DATE '1970-01-01') AS EventDate,
+    EventDate,
     CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent,
     URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID,
     URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight,

--- a/trino/create.sql
+++ b/trino/create.sql
@@ -6,7 +6,7 @@ CREATE TABLE hive.clickbench.hits_raw (
     Title varchar,
     GoodEvent smallint,
     EventTime bigint,
-    EventDate integer,
+    EventDate date,
     CounterID integer,
     ClientIP integer,
     RegionID integer,
@@ -112,14 +112,14 @@ WITH (
     format = 'PARQUET'
 );
 
--- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT)
--- and EventDate as days since 1970-01-01 (UINT16). Wrap the raw table in a view that exposes
--- the standard ClickBench types so the queries below need no further adaptation.
+-- The Parquet file stores EventTime/ClientEventTime/LocalEventTime as Unix epoch seconds (BIGINT).
+-- Wrap the raw table in a view that converts those columns to TIMESTAMP so the queries below need
+-- no further adaptation.
 CREATE VIEW hive.clickbench.hits AS
 SELECT
     WatchID, JavaEnable, Title, GoodEvent,
     from_unixtime(EventTime) AS EventTime,
-    date_add('day', EventDate, DATE '1970-01-01') AS EventDate,
+    EventDate,
     CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent,
     URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID,
     URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight,


### PR DESCRIPTION
Trino reads INT32-with-integer-annotation parquet columns as DATE since https://github.com/trinodb/trino/pull/25667, so the `date_add` view wrap on `EventDate` is no longer needed. Applied to all four Trino setups (`trino`, `trino-datalake`, `trino-partitioned`, `trino-datalake-partitioned`); validated against `hits.parquet` that results are identical.