### PR TITLE
Restore persistent cache for ClickHouse datalake entries

### DIFF
--- a/clickhouse-datalake-partitioned/flush-caches
+++ b/clickhouse-datalake-partitioned/flush-caches
@@ -2,4 +2,4 @@
 # Remove the ClickHouse filesystem cache so the cold try is really cold.
 # The harness already drops the OS page cache; this drops the layer the
 # kernel can't see.
-rm -rf cache/
+rm -rf /dev/shm/clickhouse

--- a/clickhouse-datalake-partitioned/flush-caches
+++ b/clickhouse-datalake-partitioned/flush-caches
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Remove the ClickHouse filesystem cache so the cold try is really cold.
+# The harness already drops the OS page cache; this drops the layer the
+# kernel can't see.
+rm -rf cache/

--- a/clickhouse-datalake-partitioned/flush-caches
+++ b/clickhouse-datalake-partitioned/flush-caches
@@ -1,5 +1,3 @@
 #!/bin/bash
-# Remove the ClickHouse filesystem cache so the cold try is really cold.
-# The harness already drops the OS page cache; this drops the layer the
-# kernel can't see.
+# Drop the ClickHouse filesystem cache so the cold try is really cold.
 rm -rf /dev/shm/clickhouse

--- a/clickhouse-datalake-partitioned/install
+++ b/clickhouse-datalake-partitioned/install
@@ -5,13 +5,8 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Configure a filesystem cache in tmpfs for S3 object reads, as the entry
-# used before the install/load/query refactor. Unlike the userspace page
-# cache (in-process RAM, lost when the per-query clickhouse-local process
-# exits), the filesystem cache persists across ./query invocations, so the
-# second and third tries of each query are served from local memory instead
-# of re-fetching from S3. ./flush-caches removes it before each query's
-# cold try.
+# Filesystem cache for S3 reads: unlike the in-process page cache, it
+# persists across the per-try clickhouse-local processes.
 cat > clickhouse-local.yaml <<YAML
 filesystem_caches:
     cache:

--- a/clickhouse-datalake-partitioned/install
+++ b/clickhouse-datalake-partitioned/install
@@ -5,15 +5,16 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Configure a disk-backed filesystem cache for S3 object reads. Unlike the
-# userspace page cache (in-process RAM, lost when the per-query
-# clickhouse-local process exits), the filesystem cache persists on disk
-# across ./query invocations, so the second and third tries of each query
-# are served from the local cache instead of re-fetching from S3.
-# ./flush-caches removes it before each query's cold try.
+# Configure a filesystem cache in tmpfs for S3 object reads, as the entry
+# used before the install/load/query refactor. Unlike the userspace page
+# cache (in-process RAM, lost when the per-query clickhouse-local process
+# exits), the filesystem cache persists across ./query invocations, so the
+# second and third tries of each query are served from local memory instead
+# of re-fetching from S3. ./flush-caches removes it before each query's
+# cold try.
 cat > clickhouse-local.yaml <<YAML
 filesystem_caches:
     cache:
-        path: '$(pwd)/cache/'
+        path: '/dev/shm/clickhouse/'
         max_size: '16G'
 YAML

--- a/clickhouse-datalake-partitioned/install
+++ b/clickhouse-datalake-partitioned/install
@@ -5,8 +5,15 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Use a userspace page cache sized to ~80% of RAM for S3 object reads.
-RAM=$(awk '/MemTotal/ {print int($2 * 0.8 * 1024)}' /proc/meminfo)
+# Configure a disk-backed filesystem cache for S3 object reads. Unlike the
+# userspace page cache (in-process RAM, lost when the per-query
+# clickhouse-local process exits), the filesystem cache persists on disk
+# across ./query invocations, so the second and third tries of each query
+# are served from the local cache instead of re-fetching from S3.
+# ./flush-caches removes it before each query's cold try.
 cat > clickhouse-local.yaml <<YAML
-page_cache_max_size: ${RAM}
+filesystem_caches:
+    cache:
+        path: '$(pwd)/cache/'
+        max_size: '16G'
 YAML

--- a/clickhouse-datalake-partitioned/query
+++ b/clickhouse-datalake-partitioned/query
@@ -1,10 +1,13 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the userspace page cache (sized in
-# install) for object storage reads. Stdout: query result. Stderr: query
+# datalake table created by ./load. Uses the disk-backed filesystem cache
+# (configured in install) for object storage reads; it persists across
+# per-try process invocations, so hot tries read from local disk instead of
+# re-fetching from S3. ./flush-caches drops it before each cold try.
+# Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e
 
 query=$(cat)
-./clickhouse local --path . --time --use_page_cache_for_object_storage 1 \
+./clickhouse local --path . --time --filesystem_cache_name cache \
     --format=Pretty --query="$query"

--- a/clickhouse-datalake-partitioned/query
+++ b/clickhouse-datalake-partitioned/query
@@ -1,10 +1,6 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the filesystem cache in tmpfs
-# (configured in install) for object storage reads; it persists across
-# per-try process invocations, so hot tries read from local memory instead
-# of re-fetching from S3. ./flush-caches drops it before each cold try.
-# Stdout: query result. Stderr: query
+# datalake table created by ./load. Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e
 

--- a/clickhouse-datalake-partitioned/query
+++ b/clickhouse-datalake-partitioned/query
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the disk-backed filesystem cache
+# datalake table created by ./load. Uses the filesystem cache in tmpfs
 # (configured in install) for object storage reads; it persists across
-# per-try process invocations, so hot tries read from local disk instead of
-# re-fetching from S3. ./flush-caches drops it before each cold try.
+# per-try process invocations, so hot tries read from local memory instead
+# of re-fetching from S3. ./flush-caches drops it before each cold try.
 # Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e

--- a/clickhouse-datalake/flush-caches
+++ b/clickhouse-datalake/flush-caches
@@ -2,4 +2,4 @@
 # Remove the ClickHouse filesystem cache so the cold try is really cold.
 # The harness already drops the OS page cache; this drops the layer the
 # kernel can't see.
-rm -rf cache/
+rm -rf /dev/shm/clickhouse

--- a/clickhouse-datalake/flush-caches
+++ b/clickhouse-datalake/flush-caches
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Remove the ClickHouse filesystem cache so the cold try is really cold.
+# The harness already drops the OS page cache; this drops the layer the
+# kernel can't see.
+rm -rf cache/

--- a/clickhouse-datalake/flush-caches
+++ b/clickhouse-datalake/flush-caches
@@ -1,5 +1,3 @@
 #!/bin/bash
-# Remove the ClickHouse filesystem cache so the cold try is really cold.
-# The harness already drops the OS page cache; this drops the layer the
-# kernel can't see.
+# Drop the ClickHouse filesystem cache so the cold try is really cold.
 rm -rf /dev/shm/clickhouse

--- a/clickhouse-datalake/install
+++ b/clickhouse-datalake/install
@@ -5,13 +5,8 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Configure a filesystem cache in tmpfs for S3 object reads, as the entry
-# used before the install/load/query refactor. Unlike the userspace page
-# cache (in-process RAM, lost when the per-query clickhouse-local process
-# exits), the filesystem cache persists across ./query invocations, so the
-# second and third tries of each query are served from local memory instead
-# of re-fetching from S3. ./flush-caches removes it before each query's
-# cold try.
+# Filesystem cache for S3 reads: unlike the in-process page cache, it
+# persists across the per-try clickhouse-local processes.
 cat > clickhouse-local.yaml <<YAML
 filesystem_caches:
     cache:

--- a/clickhouse-datalake/install
+++ b/clickhouse-datalake/install
@@ -5,15 +5,16 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Configure a disk-backed filesystem cache for S3 object reads. Unlike the
-# userspace page cache (in-process RAM, lost when the per-query
-# clickhouse-local process exits), the filesystem cache persists on disk
-# across ./query invocations, so the second and third tries of each query
-# are served from the local cache instead of re-fetching from S3.
-# ./flush-caches removes it before each query's cold try.
+# Configure a filesystem cache in tmpfs for S3 object reads, as the entry
+# used before the install/load/query refactor. Unlike the userspace page
+# cache (in-process RAM, lost when the per-query clickhouse-local process
+# exits), the filesystem cache persists across ./query invocations, so the
+# second and third tries of each query are served from local memory instead
+# of re-fetching from S3. ./flush-caches removes it before each query's
+# cold try.
 cat > clickhouse-local.yaml <<YAML
 filesystem_caches:
     cache:
-        path: '$(pwd)/cache/'
+        path: '/dev/shm/clickhouse/'
         max_size: '16G'
 YAML

--- a/clickhouse-datalake/install
+++ b/clickhouse-datalake/install
@@ -5,8 +5,15 @@ if [ ! -x ./clickhouse ]; then
     curl https://clickhouse.com/ | sh
 fi
 
-# Use a userspace page cache sized to ~80% of RAM for S3 object reads.
-RAM=$(awk '/MemTotal/ {print int($2 * 0.8 * 1024)}' /proc/meminfo)
+# Configure a disk-backed filesystem cache for S3 object reads. Unlike the
+# userspace page cache (in-process RAM, lost when the per-query
+# clickhouse-local process exits), the filesystem cache persists on disk
+# across ./query invocations, so the second and third tries of each query
+# are served from the local cache instead of re-fetching from S3.
+# ./flush-caches removes it before each query's cold try.
 cat > clickhouse-local.yaml <<YAML
-page_cache_max_size: ${RAM}
+filesystem_caches:
+    cache:
+        path: '$(pwd)/cache/'
+        max_size: '16G'
 YAML

--- a/clickhouse-datalake/query
+++ b/clickhouse-datalake/query
@@ -1,10 +1,13 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the userspace page cache (sized in
-# install) for object storage reads. Stdout: query result. Stderr: query
+# datalake table created by ./load. Uses the disk-backed filesystem cache
+# (configured in install) for object storage reads; it persists across
+# per-try process invocations, so hot tries read from local disk instead of
+# re-fetching from S3. ./flush-caches drops it before each cold try.
+# Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e
 
 query=$(cat)
-./clickhouse local --path . --time --use_page_cache_for_object_storage 1 \
+./clickhouse local --path . --time --filesystem_cache_name cache \
     --format=Pretty --query="$query"

--- a/clickhouse-datalake/query
+++ b/clickhouse-datalake/query
@@ -1,10 +1,6 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the filesystem cache in tmpfs
-# (configured in install) for object storage reads; it persists across
-# per-try process invocations, so hot tries read from local memory instead
-# of re-fetching from S3. ./flush-caches drops it before each cold try.
-# Stdout: query result. Stderr: query
+# datalake table created by ./load. Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e
 

--- a/clickhouse-datalake/query
+++ b/clickhouse-datalake/query
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Reads a SQL query from stdin, runs it via clickhouse-local against the S3
-# datalake table created by ./load. Uses the disk-backed filesystem cache
+# datalake table created by ./load. Uses the filesystem cache in tmpfs
 # (configured in install) for object storage reads; it persists across
-# per-try process invocations, so hot tries read from local disk instead of
-# re-fetching from S3. ./flush-caches drops it before each cold try.
+# per-try process invocations, so hot tries read from local memory instead
+# of re-fetching from S3. ./flush-caches drops it before each cold try.
 # Stdout: query result. Stderr: query
 # runtime in fractional seconds on the last line. Exit non-zero on error.
 set -e

--- a/lib/benchmark-common.sh
+++ b/lib/benchmark-common.sh
@@ -132,10 +132,7 @@ bench_wait_stopped() {
 bench_flush_caches() {
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
-    # Optional per-system hook for caches the kernel can't drop: e.g. a
-    # database-managed filesystem cache for object storage (datalake
-    # entries). Runs after the OS page cache flush so the cold try is
-    # cold for both layers.
+    # Per-system hook for caches the kernel can't drop.
     if [ -x ./flush-caches ]; then
         ./flush-caches >/dev/null 2>&1 || true
     fi

--- a/lib/benchmark-common.sh
+++ b/lib/benchmark-common.sh
@@ -132,6 +132,13 @@ bench_wait_stopped() {
 bench_flush_caches() {
     sync
     echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
+    # Optional per-system hook for caches the kernel can't drop: e.g. a
+    # database-managed filesystem cache for object storage (datalake
+    # entries). Runs after the OS page cache flush so the cold try is
+    # cold for both layers.
+    if [ -x ./flush-caches ]; then
+        ./flush-caches >/dev/null 2>&1 || true
+    fi
 }
 
 bench_install() {


### PR DESCRIPTION
Since the per-system script refactor (1f352adc), the datalake entries have no cache that survives between tries: each try runs in a fresh `clickhouse-local` process, and `--use_page_cache_for_object_storage` is an in-process cache, so every "hot" try re-fetches everything from S3. On c6a.metal, the hot-run sum for `clickhouse-datalake-partitioned` went from 18.4s (2026-05-01) to 42.0s (2026-05-09) and hot has been ≈ cold since, ~3.5x slower than `clickhouse-parquet-partitioned`.

Restore the pre-refactor mechanism (111397ad) within the new script interface: a filesystem cache in `/dev/shm/clickhouse` used via `--filesystem_cache_name`, plus a `flush-caches` hook that removes it before each query's cold cycle (the equivalent of 9c1eee0d), keeping cold runs honest.

Validated on c8g.24xlarge in eu-central-1 with these scripts: Q20 1.67s cold → 0.35s hot (local `File(Parquet)`: 0.31s); 43-query hot sum 12.6s vs 10.4s for local Parquet, against 36-39s with the current setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)