### PR TITLE
Fix reading the sink database in the results collector

### DIFF
--- a/collect-new-results.py
+++ b/collect-new-results.py
@@ -83,10 +83,12 @@ def ch(sql, **params):
         return str(value).replace("\\", "\\\\").replace("\n", "\\n") \
             .replace("\t", "\\t").replace("\r", "\\r")
 
-    url = DB_URL
-    if params:
-        encoded = urllib.parse.urlencode({f"param_{k}": escape(v) for k, v in params.items()})
-        url += ("&" if "?" in url else "?") + encoded
+    # The URL must carry at least one query parameter: play.clickhouse.com
+    # redirects the bare / to the UI, and urllib follows the redirect as a
+    # GET, losing the query and returning HTML instead of the result.
+    query = {"default_format": "JSON"}
+    query.update({f"param_{k}": escape(v) for k, v in params.items()})
+    url = DB_URL + ("&" if "?" in DB_URL else "?") + urllib.parse.urlencode(query)
     headers = {"X-ClickHouse-User": DB_USER}
     if DB_PASSWORD:
         headers["X-ClickHouse-Key"] = DB_PASSWORD


### PR DESCRIPTION
The first scheduled-able run of #996 failed with a JSON decode error: `collect-new-results.py` POSTs to `https://play.clickhouse.com/`, which redirects the bare `/` (no query parameters) to the UI with HTTP 302, and urllib follows redirects by turning the POST into a GET — the query is lost and HTML comes back. Any query parameter avoids the redirect, so `ch()` now always sends `default_format=JSON`.

Verified against the live server: with the parameter, the same request reaches ClickHouse and authenticates as `clickbench`.

Note: the `clickbench` user currently lacks its grants — both queries return `Not enough privileges`. The workflow will keep failing until this is run on the sink database:

```sql
GRANT SELECT ON sink.data TO clickbench;
GRANT SELECT ON sink.results TO clickbench;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)