### PR TITLE
Harden the ClickHouse install against 429 from clickhouse.com

### DIFF
--- a/.github/workflows/clickhouse-cloud.yml
+++ b/.github/workflows/clickhouse-cloud.yml
@@ -26,7 +26,7 @@ jobs:
         fi
 
         cd clickhouse-cloud
-        curl https://clickhouse.com/ | sh
+        curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
         sudo ./clickhouse install -y
         
         bash combinations.sh

--- a/clickhouse-datalake-partitioned/install
+++ b/clickhouse-datalake-partitioned/install
@@ -2,9 +2,6 @@
 set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 

--- a/clickhouse-datalake-partitioned/install
+++ b/clickhouse-datalake-partitioned/install
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 
 # Filesystem cache for S3 reads: unlike the in-process page cache, it

--- a/clickhouse-datalake/install
+++ b/clickhouse-datalake/install
@@ -2,9 +2,6 @@
 set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 

--- a/clickhouse-datalake/install
+++ b/clickhouse-datalake/install
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 
 # Filesystem cache for S3 reads: unlike the in-process page cache, it

--- a/clickhouse-parquet-partitioned/install
+++ b/clickhouse-parquet-partitioned/install
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi

--- a/clickhouse-parquet-partitioned/install
+++ b/clickhouse-parquet-partitioned/install
@@ -2,8 +2,5 @@
 set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi

--- a/clickhouse-parquet/install
+++ b/clickhouse-parquet/install
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi

--- a/clickhouse-parquet/install
+++ b/clickhouse-parquet/install
@@ -2,8 +2,5 @@
 set -e -o pipefail
 
 if [ ! -x ./clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi

--- a/clickhouse-web/install
+++ b/clickhouse-web/install
@@ -6,9 +6,6 @@ set -e -o pipefail
 # over HTTP from a public ClickHouse-hosted dataset.
 
 if [ ! -x /usr/bin/clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
 fi

--- a/clickhouse-web/install
+++ b/clickhouse-web/install
@@ -1,12 +1,15 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 # Note: this benchmark expects to run in eu-central-1 (Frankfurt) on an
 # n-class network-optimized machine (e.g. c5n.4xlarge), since data is fetched
 # over HTTP from a public ClickHouse-hosted dataset.
 
 if [ ! -x /usr/bin/clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
 fi
 

--- a/clickhouse/install
+++ b/clickhouse/install
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 if [ ! -x /usr/bin/clickhouse ]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
 fi
 

--- a/clickhouse/install
+++ b/clickhouse/install
@@ -2,9 +2,6 @@
 set -e -o pipefail
 
 if [ ! -x /usr/bin/clickhouse ]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
 fi

--- a/hardware/hardware.sh
+++ b/hardware/hardware.sh
@@ -8,7 +8,10 @@ pushd clickhouse-benchmark
 
 # Download the binary
 if [[ ! -x clickhouse ]]; then
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 
 if [[ ! -f $QUERIES_FILE ]]; then

--- a/hardware/hardware.sh
+++ b/hardware/hardware.sh
@@ -8,9 +8,6 @@ pushd clickhouse-benchmark
 
 # Download the binary
 if [[ ! -x clickhouse ]]; then
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
 fi
 

--- a/pg_clickhouse/install
+++ b/pg_clickhouse/install
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 PGVERSION=${PGVERSION:-17}
 
@@ -8,7 +8,10 @@ export DEBIAN_FRONTEND=noninteractive
 # --- ClickHouse ---
 if [ ! -x /usr/bin/clickhouse ]; then
     cd /tmp
-    curl https://clickhouse.com/ | sh
+    # -f and retries: when the whole daily fleet downloads at once,
+    # clickhouse.com occasionally answers 429, and without -f the error page
+    # would be piped into sh.
+    curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
     rm -f clickhouse
     cd -

--- a/pg_clickhouse/install
+++ b/pg_clickhouse/install
@@ -8,9 +8,6 @@ export DEBIAN_FRONTEND=noninteractive
 # --- ClickHouse ---
 if [ ! -x /usr/bin/clickhouse ]; then
     cd /tmp
-    # -f and retries: when the whole daily fleet downloads at once,
-    # clickhouse.com occasionally answers 429, and without -f the error page
-    # would be piped into sh.
     curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
     sudo ./clickhouse install --noninteractive
     rm -f clickhouse


### PR DESCRIPTION
13 runs of today's daily fleet failed in their first seconds — all the late-arriving Graviton and metal machines (03:16–03:43 UTC), across all six ClickHouse variants (visible in #998–#1003, e.g. the two c8g failures in #1001). Their logs show the bootstrap fetch getting rate-limited by clickhouse.com:

```
100   199  100   199 ...
sh: 1: 429:: not found
sh: 2: Syntax error: "(" unexpected
```

`curl https://clickhouse.com/ | sh` received the 199-byte "429: Too Many Requests" page and piped it into `sh`; ClickHouse was never downloaded and the run ended as a 20-second ghost. The binary hosting on builds.clickhouse.com was never reached — it is the website front door that throttled the burst.

The fix, applied to every executable occurrence of the pattern (seven `install` scripts, `hardware/hardware.sh`, and the ClickHouse Cloud workflow):

```bash
curl -fsSL --retry 10 --retry-delay 60 --retry-all-errors https://clickhouse.com/ | sh
```

- `-f`: error bodies never reach `sh`;
- `--retry 10 --retry-delay 60 --retry-all-errors`: rides out a rate-limiting burst for up to ten minutes;
- `set -o pipefail` added to the install scripts, so a download that still fails aborts the run loudly at the install step.

Verified that the hardened command downloads the bootstrap script normally, and that against a real 429 endpoint curl retries and exits 22 without printing the body. The comment occurrences in `versions/` docs are left as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)