### PR TITLE
Add GitHub star counter to benchmark pages

### DIFF
--- a/gravitons/index.html
+++ b/gravitons/index.html
@@ -81,6 +81,43 @@
             color: var(--title-color);
         }
 
+        .title-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .github-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4em;
+            font-size: 0.95rem;
+            line-height: 1;
+            text-decoration: none;
+            color: inherit;
+            border: 1px solid rgba(127, 127, 127, 0.4);
+            border-radius: 6px;
+            padding: 0.4em 0.7em;
+            background: rgba(127, 127, 127, 0.08);
+            white-space: nowrap;
+            transition: background 0.15s;
+        }
+
+        .github-stars:hover {
+            background: rgba(127, 127, 127, 0.18);
+        }
+
+        .github-stars-icon {
+            width: 1.1em;
+            height: 1.1em;
+            fill: currentColor;
+        }
+
+        .github-stars-count {
+            font-weight: 600;
+        }
+
         table {
              border-spacing: 1px;
         }
@@ -354,7 +391,14 @@ const data = [
 
 <div class="header stick-left">
     <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
-    <h1>ClickHouse Hardware Benchmark</h1>
+    <div class="title-row">
+        <h1>ClickHouse Hardware Benchmark</h1>
+        <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
+            <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+            <span>Star</span>
+            <span class="github-stars-count" id="github-stars-count"></span>
+        </a>
+    </div>
     <a href="https://github.com/ClickHouse/ClickBench/">Source</a> | <a href="https://clickhouse.com/docs/en/operations/performance-test/">Add a New Result</a> | <a href="https://github.com/ClickHouse/ClickBench/">Report Mistake</a> | <a href="https://benchmark.clickhouse.com/">Benchmark For Analytical DBMS</a> | <a href="https://benchmark.clickhouse.com/versions/">Versions Benchmark</a>
 </div>
 
@@ -807,6 +851,34 @@ if (window.location.hash) {
 render();
 updateSelectors();
 
+</script>
+<script>
+(function () {
+    var el = document.getElementById('github-stars-count');
+    if (!el) return;
+    var REPO = 'ClickHouse/ClickBench';
+    var CACHE_KEY = 'github-stars-' + REPO;
+    var TTL = 6 * 3600 * 1000;
+
+    function format(n) {
+        return '' + n;
+    }
+    function show(n) { el.textContent = format(n); }
+
+    try {
+        var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (cached && (Date.now() - cached.t) < TTL) { show(cached.n); return; }
+    } catch (e) {}
+
+    fetch('https://api.github.com/repos/' + REPO)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) {
+            if (!d || typeof d.stargazers_count !== 'number') return;
+            show(d.stargazers_count);
+            try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+        })
+        .catch(function () {});
+})();
 </script>
 </body>
 </html>

--- a/hardware/index.html
+++ b/hardware/index.html
@@ -93,6 +93,43 @@
             color: var(--title-color);
         }
 
+        .title-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .github-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4em;
+            font-size: 0.95rem;
+            line-height: 1;
+            text-decoration: none;
+            color: inherit;
+            border: 1px solid rgba(127, 127, 127, 0.4);
+            border-radius: 6px;
+            padding: 0.4em 0.7em;
+            background: rgba(127, 127, 127, 0.08);
+            white-space: nowrap;
+            transition: background 0.15s;
+        }
+
+        .github-stars:hover {
+            background: rgba(127, 127, 127, 0.18);
+        }
+
+        .github-stars-icon {
+            width: 1.1em;
+            height: 1.1em;
+            fill: currentColor;
+        }
+
+        .github-stars-count {
+            font-weight: 600;
+        }
+
         table {
              border-spacing: 1px;
         }
@@ -550,7 +587,14 @@ const data = [
 
 <div class="header stick-left">
     <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
-    <h1>ClickHouse Hardware Benchmark</h1>
+    <div class="title-row">
+        <h1>ClickHouse Hardware Benchmark</h1>
+        <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
+            <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+            <span>Star</span>
+            <span class="github-stars-count" id="github-stars-count"></span>
+        </a>
+    </div>
     <a href="https://github.com/ClickHouse/ClickBench/">Source</a> | <a href="https://clickhouse.com/docs/en/operations/performance-test/">Add a New Result</a> | <a href="https://github.com/ClickHouse/ClickBench/">Report Mistake</a> | <a href="https://benchmark.clickhouse.com/">Benchmark For Analytical DBMS</a> | <a href="https://benchmark.clickhouse.com/versions/">Versions Benchmark</a>
 </div>
 
@@ -1200,6 +1244,34 @@ if (window.location.hash) {
 updateSelectors();
 render();
 
+</script>
+<script>
+(function () {
+    var el = document.getElementById('github-stars-count');
+    if (!el) return;
+    var REPO = 'ClickHouse/ClickBench';
+    var CACHE_KEY = 'github-stars-' + REPO;
+    var TTL = 6 * 3600 * 1000;
+
+    function format(n) {
+        return '' + n;
+    }
+    function show(n) { el.textContent = format(n); }
+
+    try {
+        var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (cached && (Date.now() - cached.t) < TTL) { show(cached.n); return; }
+    } catch (e) {}
+
+    fetch('https://api.github.com/repos/' + REPO)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) {
+            if (!d || typeof d.stargazers_count !== 'number') return;
+            show(d.stargazers_count);
+            try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+        })
+        .catch(function () {});
+})();
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,43 @@
             color: var(--title-color);
         }
 
+        .title-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .github-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4em;
+            font-size: 0.95rem;
+            line-height: 1;
+            text-decoration: none;
+            color: inherit;
+            border: 1px solid rgba(127, 127, 127, 0.4);
+            border-radius: 6px;
+            padding: 0.4em 0.7em;
+            background: rgba(127, 127, 127, 0.08);
+            white-space: nowrap;
+            transition: background 0.15s;
+        }
+
+        .github-stars:hover {
+            background: rgba(127, 127, 127, 0.18);
+        }
+
+        .github-stars-icon {
+            width: 1.1em;
+            height: 1.1em;
+            fill: currentColor;
+        }
+
+        .github-stars-count {
+            font-weight: 600;
+        }
+
         table {
              border-spacing: 1px;
         }
@@ -419,7 +456,14 @@ const additional_data_size_points = [
 
 <div class="header stick-left">
     <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
-    <h1>ClickBench — a Benchmark For Analytical DBMS</h1>
+    <div class="title-row">
+        <h1>ClickBench — a Benchmark For Analytical DBMS</h1>
+        <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
+            <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+            <span>Star</span>
+            <span class="github-stars-count" id="github-stars-count"></span>
+        </a>
+    </div>
     <a href="https://github.com/ClickHouse/ClickBench/">Methodology</a> | <a href="https://github.com/ClickHouse/ClickBench/">Reproduce and Validate the Results</a> | <a href="https://github.com/ClickHouse/ClickBench/">Add a System</a> | <a href="https://benchmark.clickhouse.com/hardware/">Hardware Benchmark</a> | <a href="https://benchmark.clickhouse.com/versions/">Versions Benchmark</a> | See also: <a href="https://jsonbench.com/">JSONBench</a> | <a href="https://clickbench-playground.clickhouse.com/">🎈 Playground (new)</a>
 </div>
 
@@ -1369,6 +1413,34 @@ if (window.location.hash) {
 updateSelectors();
 render();
 
+</script>
+<script>
+(function () {
+    var el = document.getElementById('github-stars-count');
+    if (!el) return;
+    var REPO = 'ClickHouse/ClickBench';
+    var CACHE_KEY = 'github-stars-' + REPO;
+    var TTL = 6 * 3600 * 1000;
+
+    function format(n) {
+        return '' + n;
+    }
+    function show(n) { el.textContent = format(n); }
+
+    try {
+        var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (cached && (Date.now() - cached.t) < TTL) { show(cached.n); return; }
+    } catch (e) {}
+
+    fetch('https://api.github.com/repos/' + REPO)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) {
+            if (!d || typeof d.stargazers_count !== 'number') return;
+            show(d.stargazers_count);
+            try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+        })
+        .catch(function () {});
+})();
 </script>
 </body>
 </html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -8,7 +8,14 @@
 </head>
 <body>
 <header>
-    <h1>ClickBench Playground <span class="muted">&mdash; run SQL against 90+ databases</span></h1>
+    <div class="title-row">
+        <h1>ClickBench Playground <span class="muted">&mdash; run SQL against 90+ databases</span></h1>
+        <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
+            <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+            <span>Star</span>
+            <span class="github-stars-count" id="github-stars-count"></span>
+        </a>
+    </div>
 </header>
 
 <main>
@@ -65,5 +72,33 @@
 </main>
 
 <script src="app.js?v=36"></script>
+<script>
+(function () {
+    var el = document.getElementById('github-stars-count');
+    if (!el) return;
+    var REPO = 'ClickHouse/ClickBench';
+    var CACHE_KEY = 'github-stars-' + REPO;
+    var TTL = 6 * 3600 * 1000;
+
+    function format(n) {
+        return '' + n;
+    }
+    function show(n) { el.textContent = format(n); }
+
+    try {
+        var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (cached && (Date.now() - cached.t) < TTL) { show(cached.n); return; }
+    } catch (e) {}
+
+    fetch('https://api.github.com/repos/' + REPO)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) {
+            if (!d || typeof d.stargazers_count !== 'number') return;
+            show(d.stargazers_count);
+            try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+        })
+        .catch(function () {});
+})();
+</script>
 </body>
 </html>

--- a/playground/style.css
+++ b/playground/style.css
@@ -24,6 +24,30 @@ header { padding: 1em 1em; }
 header h1 { margin: 0; font-size: 22px; font-weight: 600; }
 .muted { color: var(--muted); font-weight: normal; }
 
+.title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    flex-wrap: wrap;
+}
+.github-stars {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    font-size: 13px;
+    line-height: 1;
+    text-decoration: none;
+    color: var(--fg);
+    border: 1px solid var(--muted);
+    border-radius: 6px;
+    padding: 0.4em 0.7em;
+    background: var(--bg-alt);
+    white-space: nowrap;
+}
+.github-stars:hover { background: var(--accent); color: var(--accent-fg); }
+.github-stars-icon { width: 1.1em; height: 1.1em; fill: currentColor; }
+.github-stars-count { font-weight: 600; }
+
 section { margin: 12px 0; }
 
 label { display: block; font-weight: 600; font-size: 12px; text-transform: uppercase;

--- a/versions/index.html
+++ b/versions/index.html
@@ -89,6 +89,43 @@
             color: var(--title-color);
         }
 
+        .title-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .github-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4em;
+            font-size: 0.95rem;
+            line-height: 1;
+            text-decoration: none;
+            color: inherit;
+            border: 1px solid rgba(127, 127, 127, 0.4);
+            border-radius: 6px;
+            padding: 0.4em 0.7em;
+            background: rgba(127, 127, 127, 0.08);
+            white-space: nowrap;
+            transition: background 0.15s;
+        }
+
+        .github-stars:hover {
+            background: rgba(127, 127, 127, 0.18);
+        }
+
+        .github-stars-icon {
+            width: 1.1em;
+            height: 1.1em;
+            fill: currentColor;
+        }
+
+        .github-stars-count {
+            font-weight: 600;
+        }
+
         table {
              border-spacing: 1px;
         }
@@ -413,7 +450,14 @@
 
 <div class="header stick-left">
     <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
-    <h1>ClickHouse Versions Benchmark</h1>
+    <div class="title-row">
+        <h1>ClickHouse Versions Benchmark</h1>
+        <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
+            <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
+            <span>Star</span>
+            <span class="github-stars-count" id="github-stars-count"></span>
+        </a>
+    </div>
     <a href="https://github.com/ClickHouse/ClickBench/tree/main/versions">Source</a> | <a href="https://github.com/ClickHouse/ClickBench/issues">Report Mistake</a> | <a href="https://benchmark.clickhouse.com/">Benchmark For Analytical DBMS</a> | <a href="https://benchmark.clickhouse.com/hardware">Hardware Benchmark</a>
 </div>
 
@@ -1149,6 +1193,34 @@ document.getElementById('scale_hint').textContent =
 render();
 updateSelectors();
 
+</script>
+<script>
+(function () {
+    var el = document.getElementById('github-stars-count');
+    if (!el) return;
+    var REPO = 'ClickHouse/ClickBench';
+    var CACHE_KEY = 'github-stars-' + REPO;
+    var TTL = 6 * 3600 * 1000;
+
+    function format(n) {
+        return '' + n;
+    }
+    function show(n) { el.textContent = format(n); }
+
+    try {
+        var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (cached && (Date.now() - cached.t) < TTL) { show(cached.n); return; }
+    } catch (e) {}
+
+    fetch('https://api.github.com/repos/' + REPO)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (d) {
+            if (!d || typeof d.stargazers_count !== 'number') return;
+            show(d.stargazers_count);
+            try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count, t: Date.now() })); } catch (e) {}
+        })
+        .catch(function () {});
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Adds a GitHub star counter to the right of the title on every benchmark HTML page:

- `index.html` (main ClickBench)
- `hardware/index.html`
- `versions/index.html`
- `gravitons/index.html`
- `playground/index.html`

## Details

- Each `<h1>` and a new star badge are wrapped in a `<div class="title-row">` (flexbox), so the counter sits inline to the right of the title and wraps gracefully on narrow screens.
- The badge is a styled pill with a GitHub star octicon, a "Star" label, and the **full live star count** (e.g. `1234`, not `1.2k`), linking to the repo.
- A small inline script fetches `stargazers_count` from the GitHub REST API and caches it in `localStorage` for 6 hours to avoid unauthenticated rate limits on repeat visits.
- Graceful degradation: if the API call fails or is rate-limited, the badge still shows "★ Star" and links to the repo — just without a number.
- Colors are theme-neutral on the four main pages (light/dark) and use the playground's own CSS variables on the playground page.

The hardware/gravitons `generate-results.sh` scripts only rewrite the in-page data block, so these header/script edits survive regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)