### PR TITLE
Point Playground links at benchmark.clickhouse.com/playground/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changes in the benchmark methodology or presentation, as well as major news.
 
 ### 2026-07-22
-Introducing [ClickBench Playground](https://clickbench-playground.clickhouse.com/), which allows you to run arbitrary SQL queries on 90+ databases using a pre-loaded ClickBench dataset.
+Introducing [ClickBench Playground](https://benchmark.clickhouse.com/playground/), which allows you to run arbitrary SQL queries on 90+ databases using a pre-loaded ClickBench dataset.
 
 ### 2026-07-03
 The [versions benchmark](https://benchmark.clickhouse.com/versions/) is reworked. Now it contains 10 datasets and runs every ClickHouse version since [ten years of open source](https://clickhouse.com/blog/open-source-10) and even early historical builds. The visualization was also improved.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Systems that have been identified to have known limitations or issues and could 
 
 ## Bonus
 
-You can run every system from ClickBench in the [online Playground](https://clickbench-playground.clickhouse.com/).
+You can run every system from ClickBench in the [online Playground](https://benchmark.clickhouse.com/playground/).
 
 ## Similar Projects
 

--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@ const additional_data_size_points = [
 <div class="header stick-left">
     <span class="nowrap themes"><span id="toggle-dark">🌚</span><span id="toggle-light">🌞</span></span>
     <h1>ClickBench — a Benchmark For Analytical DBMS</h1>
-    <a href="https://github.com/ClickHouse/ClickBench/">Methodology</a> | <a href="https://github.com/ClickHouse/ClickBench/">Reproduce and Validate the Results</a> | <a href="https://github.com/ClickHouse/ClickBench/">Add a System</a> | <a href="https://benchmark.clickhouse.com/hardware/">Hardware Benchmark</a> | <a href="https://benchmark.clickhouse.com/versions/">Versions Benchmark</a> | See also: <a href="https://jsonbench.com/">JSONBench</a> | <a href="https://clickbench-playground.clickhouse.com/">🎈 Playground (new)</a>
+    <a href="https://github.com/ClickHouse/ClickBench/">Methodology</a> | <a href="https://github.com/ClickHouse/ClickBench/">Reproduce and Validate the Results</a> | <a href="https://github.com/ClickHouse/ClickBench/">Add a System</a> | <a href="https://benchmark.clickhouse.com/hardware/">Hardware Benchmark</a> | <a href="https://benchmark.clickhouse.com/versions/">Versions Benchmark</a> | See also: <a href="https://jsonbench.com/">JSONBench</a> | <a href="https://benchmark.clickhouse.com/playground/">🎈 Playground (new)</a>
 </div>
 
 <table class="selectors-container stick-left">


### PR DESCRIPTION
Now that the UI lives at benchmark.clickhouse.com/playground/ (via GitHub Pages, alongside the rest of the ClickBench site) the old clickbench-playground.clickhouse.com URL is no longer the canonical entry point.

Update the three visitor-facing references — index.html (footer), README.md (running-the-benchmark section), CHANGELOG.md (initial Playground announcement) — to the new path.
