### PR TITLE
playground: switch mount options to compress-force=zstd:6

### DIFF
--- a/playground/INSTALL.md
+++ b/playground/INSTALL.md
@@ -26,10 +26,37 @@ both. XFS works for reflink but lacks compression and fills the host at
 ```
 sudo mkfs.btrfs -L cbplayground -f /dev/<your-device>
 echo 'LABEL=cbplayground /opt/clickbench-playground btrfs \
-    defaults,noatime,compress=zstd:1,nofail 0 2' | sudo tee -a /etc/fstab
+    defaults,noatime,compress-force=zstd:6,nofail 0 2' | sudo tee -a /etc/fstab
 sudo mkdir -p /opt/clickbench-playground
 sudo mount /opt/clickbench-playground
 ```
+
+Notes on the mount options:
+
+- `compress-force` (not `compress`): btrfs' default heuristic samples the
+  first 128 KiB of each file and skips compression when that head looks
+  incompressible. For the ext4 disk images we write the sparse-metadata
+  head throws the sampler off, and roughly 80 % of the data ends up
+  stored raw. `compress-force` disables the heuristic and compresses
+  everything.
+- `zstd:6` (not `zstd:1`): the ratio delta on the compressible portion
+  is modest (~10 %), but it adds up over 6+ TiB of goldens. Compression
+  speed drops from ~500 MB/s to ~120 MB/s per core — writeback stays
+  disk-bound anyway, and the CPU is idle during provisioning.
+
+If you're upgrading an existing playground volume from `compress=zstd:1`,
+remount with the new options and then re-encode existing extents:
+
+```
+sudo mount -o remount,compress-force=zstd:6 /opt/clickbench-playground
+sudo btrfs filesystem defragment -r -f -czstd -t 128M \
+    /opt/clickbench-playground/systems
+```
+
+The defrag pass is heavy (rewrites all extents; 20 h–3 days for a 7 TiB
+volume) and briefly increases disk usage while old extents remain
+reflink-referenced by golden files. Run it under `ionice -c 3 nice -n 15`
+if the playground is serving live traffic.
 
 ## 2. Clone the repo
 

--- a/playground/scripts/install-firecracker.sh
+++ b/playground/scripts/install-firecracker.sh
@@ -26,8 +26,21 @@ sudo chown "$(id -u):$(id -g)" \
 #
 #   sudo mkfs.btrfs -L cbplayground -f /dev/<your-device>
 #   echo 'LABEL=cbplayground /opt/clickbench-playground btrfs \
-#       defaults,noatime,compress=zstd:1,nofail 0 2' | sudo tee -a /etc/fstab
+#       defaults,noatime,compress-force=zstd:6,nofail 0 2' | sudo tee -a /etc/fstab
 #   sudo mount /opt/clickbench-playground
+#
+# Notes on the mount options:
+#   - compress-force (not compress): the default heuristic samples the
+#     first 128 KiB of each file and skips compression if that head
+#     looks incompressible. For the ext4 disk images we write, the
+#     sparse-metadata head throws off the sampler and ~80 % of the
+#     data ends up stored raw. `compress-force` disables the heuristic
+#     and gets the whole file compressed.
+#   - zstd:6 (not zstd:1): the on-disk savings from 6-vs-1 are modest
+#     for the compressible portion (~10 %), but 6's higher ratio adds
+#     up over 6+ TiB of goldens. Compression speed drops from ~500
+#     MB/s to ~120 MB/s per core — writeback stays disk-bound anyway,
+#     and the CPU is otherwise idle during provisioning.
 #
 # (XFS also works for reflink but doesn't have transparent compression,
 # so on XFS the host fills up at ~7 TB once every system is provisioned.)


### PR DESCRIPTION
Existing INSTALL guidance said compress=zstd:1. Running compsize against the live playground volume showed 80 % of the 7 TiB of per-system data was stored raw — btrfs' compression heuristic samples the first 128 KiB of each file and skips compression when that head looks incompressible, and the sparse-metadata head of our ext4 disk images consistently fools the sampler.

Switch to compress-force=zstd:6:
  - compress-force disables the heuristic (compresses everything).
  - zstd:6 gives ~10 % more ratio than :1 on the compressible portion at ~4× the CPU cost per byte; provisioning is disk- bound anyway.

Also document the online upgrade path (remount + btrfs filesystem defragment -czstd) for operators moving off compress=zstd:1.
