### PR TITLE
Playground: bump "90+ databases" to "110+ databases"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changes in the benchmark methodology or presentation, as well as major news.
 
 ### 2026-07-22
-Introducing [ClickBench Playground](https://benchmark.clickhouse.com/playground/), which allows you to run arbitrary SQL queries on 90+ databases using a pre-loaded ClickBench dataset.
+Introducing [ClickBench Playground](https://benchmark.clickhouse.com/playground/), which allows you to run arbitrary SQL queries on 110+ databases using a pre-loaded ClickBench dataset.
 
 ### 2026-07-03
 The [versions benchmark](https://benchmark.clickhouse.com/versions/) is reworked. Now it contains 10 datasets and runs every ClickHouse version since [ten years of open source](https://clickhouse.com/blog/open-source-10) and even early historical builds. The visualization was also improved.

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ClickBench Playground &mdash; run SQL against 90+ databases</title>
+<title>ClickBench Playground &mdash; run SQL against 110+ databases</title>
 <link rel="stylesheet" href="style.css?v=23">
 </head>
 <body>
 <header>
     <div class="title-row">
-        <h1>ClickBench Playground <span class="muted">&mdash; run SQL against 90+ databases</span></h1>
+        <h1>ClickBench Playground <span class="muted">&mdash; run SQL against 110+ databases</span></h1>
         <a class="github-stars" href="https://github.com/ClickHouse/ClickBench/" target="_blank" rel="noopener noreferrer" aria-label="Star ClickBench on GitHub" title="Star ClickBench on GitHub">
             <svg class="github-stars-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg>
             <span>Star</span>


### PR DESCRIPTION
Catalog is at 119 systems now; 110 are provisioned & queryable at the time of writing (72 snapshotted + 38 recently active). The "90+" number was from the original launch write-up.
