### PR TITLE
hyrise: pass split -a3 so 100 chunks work

### DIFF
--- a/hyrise/load
+++ b/hyrise/load
@@ -38,7 +38,10 @@ if [ ! -f data/hits.bin ]; then
         lines_per_piece=1000000
     fi
     if [ -f hits.csv ]; then
-        split -l "$lines_per_piece" --numeric-suffixes=1 --additional-suffix=.csv \
+        # -a3: 3-digit suffixes so 100+ pieces work. Default (-a2) gives
+        # 01..99 and fails with "output file suffixes exhausted" once
+        # we cross 100 pieces (lines_per_piece=1000000 → 100 pieces).
+        split -a3 -l "$lines_per_piece" --numeric-suffixes=1 --additional-suffix=.csv \
             hits.csv data/hits_part_
         rm hits.csv
     fi


### PR DESCRIPTION
Bumping the per-piece row count to 1 M rows means the split output is 100 pieces (hits_part_001.csv … hits_part_100.csv). `split`'s default --numeric-suffixes suffix width is -a2, which caps at 01..99 — the 100th write fails with

    split: output file suffixes exhausted

and load exits rc=1 133 s into the CSV split (hyrise never sees the first piece). Pass -a3 explicitly.
