### PR TITLE
Playground: re-provision systems whose scripts changed in the repo

### DIFF
--- a/playground/INSTALL.md
+++ b/playground/INSTALL.md
@@ -252,6 +252,31 @@ Boots one system end-to-end (provision → snapshot → restore → /query),
 prints timing, tears down. Use this to validate any change to
 `base-rootfs.ext4` or the agent before re-kicking the full catalog.
 
+## Re-provisioning after a system's scripts change
+
+A snapshot pins the engine version `install` fetched and the schema
+`create.sql` declared when it was built, but the example queries the UI
+offers are read from the live repo. Bump a system in the repo and the two
+drift apart — QuestDB served 9.3.1 for two months after the repo moved to
+9.3.5, so the two `length_bytes()` examples (a 9.3.2 function) failed with
+"unknown function name".
+
+`/api/system/<name>` reports `source_stale: true` once a system's files
+differ from the fingerprint stamped at provision time
+(`<state>/systems/<name>/source.sha256`; `results/`, `template.json` and
+READMEs are excluded, since they never reach the VM). `provision-all.sh`
+re-kicks those even with `SKIP_PROVISIONED=yes`, so the usual
+
+```
+git pull && playground/scripts/provision-all.sh
+```
+
+picks up engine bumps. To refresh one system:
+
+```
+curl -X POST http://localhost:8000/api/admin/provision/<name>
+```
+
 ## Re-provisioning after agent or base-image changes
 
 `vm_manager` rebuilds the per-system rootfs+sysdisk automatically when

--- a/playground/scripts/provision-all.sh
+++ b/playground/scripts/provision-all.sh
@@ -19,14 +19,24 @@ mapfile -t SYSTEMS < <(
 
 echo "$(date -Is) catalog: ${#SYSTEMS[@]} systems"
 
-# Kick off /provision for each system that isn't already snapshotted.
+# Kick off /provision for each system that isn't already snapshotted from
+# the current scripts. A system whose install/create.sql/queries.sql moved
+# on in the repo since its snapshot was taken (source_stale) is re-kicked
+# even under SKIP_PROVISIONED — otherwise it serves the engine version it
+# was first provisioned with forever, while the UI hands out examples from
+# today's queries.sql.
 for sys in "${SYSTEMS[@]}"; do
     if [ "$SKIP_PROVISIONED" = "yes" ]; then
-        state=$(curl -fsS "$BASE/api/system/$sys" |
-                python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
-        if [ "$state" = "snapshotted" ] || [ "$state" = "ready" ]; then
+        info=$(curl -fsS "$BASE/api/system/$sys" |
+                python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["state"], d.get("source_stale", False))')
+        read -r state stale <<< "$info"
+        if { [ "$state" = "snapshotted" ] || [ "$state" = "ready" ]; } &&
+           [ "$stale" != "True" ]; then
             echo "  $sys: skip (already $state)"
             continue
+        fi
+        if [ "$stale" = "True" ]; then
+            echo "  $sys: scripts changed since snapshot — re-provisioning"
         fi
     fi
     echo "  $sys: kicking provision"

--- a/playground/server/main.py
+++ b/playground/server/main.py
@@ -215,6 +215,11 @@ class App:
             **self.systems[name].asdict(),
             "state": vm.state,
             "has_snapshot": vm.snapshot_bin.exists(),
+            # Whether the system's scripts moved on in the repo since this
+            # snapshot was taken. Per-system rather than part of /api/state
+            # because it hashes the system's files and /api/state is polled
+            # every 2 s by every open tab.
+            "source_stale": self.vmm.source_stale(name),
             "provisioned_at": vm.provisioned_at,
             "last_used": vm.last_used,
             "ready_since": vm.ready_since,

--- a/playground/server/systems.py
+++ b/playground/server/systems.py
@@ -17,6 +17,7 @@ The registry is built by scanning the repo at startup. Each `System` carries:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass, field
@@ -163,6 +164,54 @@ class System:
             "durable": self.durable,
             "restartable": self.restartable,
         }
+
+
+def _source_files(system_dir: Path) -> list[Path]:
+    """The system's files that end up inside its VM, sorted.
+
+    Mirrors the `--exclude` list in images/build-system-rootfs.sh: the
+    result JSONs, the frontend metadata and the READMEs never reach the
+    guest, and `results/` in particular gets new files every week — a
+    fingerprint that moved on every results commit would mark the whole
+    catalog stale for no reason.
+    """
+    out = []
+    for p in sorted(system_dir.rglob("*")):
+        rel = p.relative_to(system_dir)
+        if rel.parts[0] == "results" or p.name == "template.json" \
+                or p.name.startswith("README"):
+            continue
+        if p.is_file():
+            out.append(p)
+    return out
+
+
+def source_fingerprint(system_dir: Path) -> str:
+    """SHA-256 over a system's ClickBench scripts.
+
+    A snapshot is only as current as the scripts it was provisioned
+    from: `install` pins the engine version, `create.sql` the schema,
+    `load` the ingest path. When any of them change in the repo the
+    snapshot is stale and the system needs a re-provision — see
+    VMManager.source_stale.
+    """
+    h = hashlib.sha256()
+    for p in _source_files(system_dir):
+        h.update(str(p.relative_to(system_dir)).encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def source_mtime(system_dir: Path) -> float:
+    """Newest mtime among the files source_fingerprint() hashes.
+
+    Only used for snapshots taken before fingerprints were stamped, where
+    there is nothing to compare a hash against.
+    """
+    return max((p.stat().st_mtime for p in _source_files(system_dir)),
+               default=0.0)
 
 
 def _read_template(p: Path) -> dict:

--- a/playground/server/vm_manager.py
+++ b/playground/server/vm_manager.py
@@ -37,7 +37,9 @@ from . import firecracker as fc
 from . import net
 from .systems import NEEDS_SWAP, SWAP_SIZE_GB, SYSDISK_OVERRIDES_GB
 from .config import Config
-from .systems import System, DATALAKE_FILTERED
+from .systems import (
+    System, DATALAKE_FILTERED, source_fingerprint, source_mtime,
+)
 
 log = logging.getLogger("vm_manager")
 
@@ -185,6 +187,38 @@ class VMManager:
             vm.state = "down"
             self._set_last_error(vm, None)
             await self._initial_provision(vm)
+
+    def source_stale(self, system: str) -> bool:
+        """True when the snapshot no longer matches the system's scripts.
+
+        A snapshot freezes whatever `install` fetched and `create.sql`
+        declared on the day it was built, but the examples the UI serves
+        come from the live repo (main.py:handle_queries). Nothing used to
+        reconcile the two: provision-all.sh skips any system that already
+        has a snapshot, so a system stayed on its original engine version
+        indefinitely. QuestDB sat on 9.3.1 for two months after the repo
+        moved to 9.3.5, against a queries.sql that had switched to
+        `length_bytes()` — a function 9.3.1 doesn't have, so two of the
+        playground's own examples answered "unknown function name".
+        """
+        vm = self.vms.get(system)
+        if vm is None or not _has_snapshot(vm):
+            return False
+        src = self.cfg.repo_dir / system
+        stamp = self._source_stamp(vm)
+        if stamp.exists():
+            return stamp.read_text().strip() != source_fingerprint(src)
+        # Snapshot predates fingerprint stamping, so there's no hash to
+        # compare against. Fall back to mtimes: only systems whose scripts
+        # were touched after the snapshot was taken count as stale, which
+        # keeps adopting this from re-provisioning the whole catalog.
+        # _has_snapshot doesn't look at snapshot.state, so it may be gone;
+        # treat that as stale rather than raising out of /api/system.
+        try:
+            snapshot_mtime = vm.snapshot_state.stat().st_mtime
+        except OSError:
+            return True
+        return source_mtime(src) > snapshot_mtime
 
     async def ensure_ready_for_query(self, system: str) -> VM:
         """Make sure system is up and responsive to /query. Boot/resume as needed.
@@ -355,6 +389,13 @@ class VMManager:
                     await net.disable_internet(vm.slot)
             vm.state = "snapshotted"
             vm.provisioned_at = time.time()
+            # Record which revision of the system's scripts this snapshot
+            # came from, so a later change in the repo is detectable
+            # (source_stale). Written last: a snapshot we failed to take
+            # must not look current.
+            with contextlib.suppress(Exception):
+                self._source_stamp(vm).write_text(
+                    source_fingerprint(self.cfg.repo_dir / vm.system.name) + "\n")
             log.info("[%s] initial provision complete", vm.system.name)
         except Exception as e:
             self._set_last_error(vm, f"provision: {e!r}")
@@ -685,6 +726,10 @@ class VMManager:
         # Baseline the firecracker's current jiffy counter so the
         # per-VM CPU-cap watchdog can bill only post-ready CPU time.
         vm.cpu_baseline_jiffies = _read_proc_jiffies(vm.pid) if vm.pid else 0
+
+    def _source_stamp(self, vm: VM) -> Path:
+        """Fingerprint of the scripts this system was last provisioned from."""
+        return self.cfg.systems_dir / vm.system.name / "source.sha256"
 
     def _golden_paths(self, vm: VM) -> tuple[Path, Path, Path, Path]:
         """(working rootfs, working sysdisk, golden rootfs, golden sysdisk)."""

--- a/questdb/install
+++ b/questdb/install
@@ -3,9 +3,20 @@ set -eu
 
 qdb_version="${QDB_VERSION:-9.3.5}"
 
-if [ -d questdb/bin ]; then
+# Skip only when the version already installed is the one being asked for.
+# A bare `[ -d questdb/bin ]` check made this script a permanent no-op on
+# any working directory that survives a run: bumping QDB_VERSION (or the
+# default above) then silently kept benchmarking the old binaries.
+if [ -d questdb/bin ] && \
+   [ "$(cat questdb/.clickbench-version 2>/dev/null)" = "$qdb_version" ]; then
     exit 0
 fi
+
+# Nothing installed, or a different version is. Start clean: the untar
+# globs below match `questdb*.tar.gz`, so a leftover tarball from another
+# version would make them ambiguous. Paths are relative to this system
+# directory, which is where every path in this script lives.
+rm -rf ./questdb ./graalvm ./questdb-*.tar.gz ./graalvm-community-*.tar.gz
 
 if [[ $(arch) == "aarch64" ]] || [[ $(arch) == arm* ]]; then
     # ARM uses no-JRE binary, so we install GraalVM JDK alongside.
@@ -28,3 +39,5 @@ else
         "https://github.com/questdb/questdb/releases/download/${qdb_version}/questdb-${qdb_version}-rt-linux-x86-64.tar.gz"
     tar xf questdb*.tar.gz --one-top-level=questdb --strip-components 1
 fi
+
+echo "$qdb_version" > questdb/.clickbench-version


### PR DESCRIPTION
## The symptom

Two of the playground's own QuestDB examples fail:

```
$ curl -sS -X POST 'https://clickbench-playground.clickhouse.com/api/query?system=questdb' \
       --data-binary "SELECT length_bytes('abc');"
{"error":"unknown function name: length_bytes(STRING)","position":7}
```

`length_bytes()` is what Q28 and Q29 in `questdb/queries.sql` use, and the
playground offers both from its Example dropdown.

## Why

The engine there is not the one the repo describes:

```
$ ... --data-binary 'SELECT build();'
Build Information: QuestDB 9.3.1, JDK 17.0.9, Commit Hash 5480b2d...
```

- `questdb/install` has pinned **9.3.5** since #902 (merged 2026-06-30).
- `questdb/queries.sql` switched Q28/Q29 to `length_bytes()` in 5305bf20f
  (2026-03-05), to match ClickHouse's byte semantics — QuestDB's `length()`
  counts characters on VARCHAR. `length_bytes()` first shipped in
  [9.3.2](https://github.com/questdb/questdb/commit/667eefc340f5d0365d84075d885a8ecdc362ec28).
- The playground snapshot is from ~2026-05-12, when the repo still pinned
  9.3.1.

So the VM is two months behind the scripts. The mismatch is structural
rather than QuestDB-specific: `handle_queries` reads `queries.sql` from the
live repo checkout on the host, while the engine answering comes from a
snapshot built whenever that system was first provisioned. Nothing
reconciles the two — `provision-all.sh` skips every system that already has
a snapshot, and `INSTALL.md` only documents re-provisioning after **agent**
or **base-image** changes. A system's own `install`/`create.sql`/`queries.sql`
can move arbitrarily far without anything noticing.

## The fix

- `systems.py`: `source_fingerprint()` — SHA-256 over the files that
  actually reach the VM. Excludes `results/`, `template.json` and READMEs,
  mirroring the `--exclude` list in `build-system-rootfs.sh`; otherwise every
  auto-results commit would mark the catalog stale.
- `vm_manager.py`: stamp it at `<state>/systems/<name>/source.sha256` after
  a successful provision, and add `VMManager.source_stale()`.
- `main.py`: expose `source_stale` on `/api/system/<name>`. Deliberately not
  on `/api/state` — that one is polled every 2 s by every open tab, and this
  hashes files.
- `provision-all.sh`: re-kick stale systems even under `SKIP_PROVISIONED=yes`,
  so `git pull && provision-all.sh` picks up engine bumps.
- `INSTALL.md`: document it.

Existing snapshots have no stamp, so they fall back to comparing the
system's newest source mtime against `snapshot.state`'s. That keeps adopting
this from re-provisioning all 120 systems at once — only the ones whose
scripts really moved get re-kicked.

Also: `questdb/install` began with `[ -d questdb/bin ] && exit 0`, which made
it a permanent no-op — any working directory that survives a run keeps the
first version installed no matter how `QDB_VERSION` moves. Now it stamps the
installed version and reinstalls when it differs (clearing the old tarball
too, since the untar globs are `questdb*.tar.gz`).

## Testing

- `source_stale()` against a temp state dir over six cases: no snapshot,
  legacy snapshot with newer/older scripts, stamped and unchanged, stamped
  with `install` edited, and stamped with a new `results/` file added (must
  stay fresh). All as expected.
- `provision-all.sh`'s skip decision for `snapshotted`/`ready` × fresh/stale,
  `down`, and a server that doesn't yet report the field (skips, as before).
- `questdb/install` with stubbed `wget`/`tar`: fresh install stamps 9.3.5;
  re-run makes no network calls; `QDB_VERSION=9.4.3` re-downloads, replaces
  the tarball and re-stamps; a `questdb/bin` with no stamp reinstalls.

Not exercised: an actual provision run (needs the Firecracker host).

## After merging

The QuestDB snapshot won't fix itself — it needs one re-provision:

```
curl -X POST http://localhost:8000/api/admin/provision/questdb
```

Other systems bumped since their snapshot was taken will be picked up by the
next `provision-all.sh` run. Happy to split the `questdb/install` change into
its own PR if you'd rather keep this to the playground.
