### PR TITLE
Process final query without trailing newline

### DIFF
--- a/lib/benchmark-common.sh
+++ b/lib/benchmark-common.sh
@@ -348,7 +348,7 @@ bench_concurrent_qps() {
 
     # Read the same query file that bench_run_query consumed.
     local queries=() q
-    while IFS= read -r q; do
+    while IFS= read -r q || [ -n "$q" ]; do
         [ -z "$q" ] && continue
         queries+=("$q")
     done < "$BENCH_QUERIES_FILE"
@@ -476,7 +476,7 @@ bench_main() {
 
     : > result.csv
     local query_num=1
-    while IFS= read -r query; do
+    while IFS= read -r query || [ -n "$query" ]; do
         # Skip empty lines.
         [ -z "$query" ] && continue
         bench_run_query "$query" "$query_num"


### PR DESCRIPTION
## Summary

- preserve the final query when a query file does not end with a newline
- apply the fix to both the regular benchmark sweep and concurrent QPS query loader

## Why

Bash `read` fills the variable but returns a non-zero status when it reaches EOF before a newline. Since that status controls these loops, the last query was silently skipped for unterminated query files.

## Testing

- verified both newline-terminated and unterminated two-query inputs process both queries in order
- `bash -n lib/benchmark-common.sh`
- `shellcheck lib/benchmark-common.sh`