### PR TITLE
Exclude late completions from concurrent QPS

### DIFF
--- a/lib/benchmark-common.sh
+++ b/lib/benchmark-common.sh
@@ -424,14 +424,24 @@ print('\n'.join(map(str, xs)))
 PY
 )
 
-            local ok=0 err=0 idx=0 qi q_text
+            local ok=0 err=0 idx=0 qi q_text outcome
             while [ "$(date +%s)" -lt "$deadline" ]; do
                 qi="${perm[$idx]}"
                 q_text="${queries[$qi]}"
                 if printf '%s\n' "$q_text" | ./query >/dev/null 2>&1; then
-                    ok=$((ok + 1))
+                    outcome=ok
                 else
-                    err=$((err + 1))
+                    outcome=err
+                fi
+                # QPS is completions within the fixed wall-clock window.
+                # Do not include a query merely because it started before
+                # the deadline if it only completed after the window ended.
+                if [ "$(date +%s)" -lt "$deadline" ]; then
+                    if [ "$outcome" = ok ]; then
+                        ok=$((ok + 1))
+                    else
+                        err=$((err + 1))
+                    fi
                 fi
                 idx=$(( (idx + 1) % nq ))
             done


### PR DESCRIPTION
## Summary

Count concurrent query outcomes only when the query completes within the configured benchmark window.

## Why

Workers currently check the deadline before starting a query, but increment their counters after it finishes regardless of completion time. A query started just before the deadline can finish much later and still be included in `concurrent_qps`, which is divided by the original fixed duration.

With two workers, a two-second window, and queries that take three seconds, no query completes during the window, but the current code reports `1.000` QPS. After this change both late completions are excluded and the result is `null`. Workers still finish their in-flight queries normally; this does not introduce client cancellation or leave server-side work behind.

## Testing

- real `bench_concurrent_qps` probe: late successes produce null QPS
- real `bench_concurrent_qps` probe: late failures produce null error ratio
- real `bench_concurrent_qps` probe: in-window successes are still counted
- `bash -n lib/benchmark-common.sh`
- `shellcheck lib/benchmark-common.sh`
- `git diff --check`