### PR TITLE
Benchmark single-replica ClickHouse Cloud services of all sizes

### DIFF
--- a/clickhouse-cloud/combinations.sh
+++ b/clickhouse-cloud/combinations.sh
@@ -8,9 +8,11 @@ PROVIDER=aws
 REGION='ap-southeast-2'
 PARALLEL_REPLICA=false
 
-for REPLICAS in 1
+# The Scale tier supports single-replica services of every size,
+# so all replica counts run over the full range of memory sizes.
+for REPLICAS in 1 2 3
 do
-    for MEMORY in 8 12
+    for MEMORY in 8 12 16 32 64 120 236 356
     do
         export PROVIDER REPLICAS REGION MEMORY PARALLEL_REPLICA
         ./cloud-api.sh &
@@ -18,30 +20,10 @@ do
     done
 done
 
-for REPLICAS in 2 3
-do
-    for MEMORY in 8 12 16 32 64 120 236 356
-    do
-        export PROVIDER REPLICAS REGION MEMORY PARALLEL_REPLICA
-        ./cloud-api.sh &
-        sleep 10
-    done
-done
-
 PROVIDER=gcp
 REGION='us-east1'
 
-for REPLICAS in 1
-do
-    for MEMORY in 8 12
-    do
-        export PROVIDER REPLICAS REGION MEMORY PARALLEL_REPLICA
-        ./cloud-api.sh &
-        sleep 10
-    done
-done
-
-for REPLICAS in 2 3
+for REPLICAS in 1 2 3
 do
     for MEMORY in 8 12 16 32 64 120 236 356
     do
@@ -54,17 +36,7 @@ done
 PROVIDER=azure
 REGION='westus3'
 
-for REPLICAS in 1
-do
-    for MEMORY in 8 12
-    do
-        export PROVIDER REPLICAS REGION MEMORY PARALLEL_REPLICA
-        ./cloud-api.sh &
-        sleep 10
-    done
-done
-
-for REPLICAS in 2 3
+for REPLICAS in 1 2 3
 do
     for MEMORY in 8 12 16 32 64 120 236 356
     do


### PR DESCRIPTION
ClickHouse Cloud added a single-replica option to the Scale tier, so 1-replica services are no longer limited to 8 and 12 GiB.

This merges the per-provider loops in `clickhouse-cloud/combinations.sh` so every replica count (1, 2, 3) runs over the full memory range (8..356 GiB) on AWS, GCP, and Azure — adding 18 new single-replica configurations. Verified against the live Cloud API spec that `numReplicas` now has a minimum of 1 with the full 8–356 GiB memory range.

No other script changes are needed: `cloud-api.sh` already passes `$REPLICAS` into `numReplicas`, and `collect-results.sh` derives `cluster_size` from the temp-directory name, so new results will land as e.g. `results/<date>/aws.1.32.json` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)