### PR TITLE
Hyper Parquet: Disable sampling

### DIFF
--- a/hyper-parquet-partitioned/start
+++ b/hyper-parquet-partitioned/start
@@ -40,7 +40,12 @@ signal.signal(signal.SIGINT, _terminate)
 
 with HyperProcess(
     telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU,
-    parameters={"experimental_persisted_external_tables": "on"},
+    parameters={
+        "experimental_persisted_external_tables": "on",
+        # External-table samples are useful for complex queries but meaningless
+        # for ClickBench's rather simple queries
+        "external_sampling": "false",
+    },
 ) as hyper:
     # Keep-alive: hold hits_parquet.hyper attached for the server lifetime so
     # its external-table catalog (and the plan-cache entries depending on it)

--- a/hyper-parquet-single/start
+++ b/hyper-parquet-single/start
@@ -40,7 +40,12 @@ signal.signal(signal.SIGINT, _terminate)
 
 with HyperProcess(
     telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU,
-    parameters={"experimental_persisted_external_tables": "on"},
+    parameters={
+        "experimental_persisted_external_tables": "on",
+        # External-table samples are not persisted, so every cold restart would
+        # otherwise resample the wide Parquet table before executing the query.
+        "external_sampling": "false",
+    },
 ) as hyper:
     # Keep-alive: hold hits_parquet.hyper attached for the server lifetime so
     # its external-table catalog (and the plan-cache entries depending on it)


### PR DESCRIPTION
Disable creation of Parquet samples so the benchmark measures query execution rather than being over-shadowed by optimizer sampling