### PR TITLE
Additional queries for ClickBench by DeepSeek V4 Flash

### DIFF
--- a/clickhouse-parquet/queries.sql
+++ b/clickhouse-parquet/queries.sql
@@ -41,3 +41,18 @@ SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN (SearchEngineID = 
 SELECT URLHash, EventDate, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND TraficSourceID IN (-1, 6) AND RefererHash = 3594120000172545465 GROUP BY URLHash, EventDate ORDER BY PageViews DESC LIMIT 10 OFFSET 100;
 SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND DontCountHits = 0 AND URLHash = 2868770270353813622 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY PageViews DESC LIMIT 10 OFFSET 10000;
 SELECT DATE_TRUNC('minute', EventTime) AS M, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-14' AND EventDate <= '2013-07-15' AND IsRefresh = 0 AND DontCountHits = 0 GROUP BY DATE_TRUNC('minute', EventTime) ORDER BY DATE_TRUNC('minute', EventTime) LIMIT 10 OFFSET 1000;
+SELECT UserID, RANK() OVER (ORDER BY EventTime) AS r FROM hits ORDER BY r DESC LIMIT 10;
+SELECT * FROM hits ORDER BY ClientIP, EventTime LIMIT 100;
+SELECT CounterID, avg(length(Referer)) AS l FROM hits WHERE Referer <> '' GROUP BY CounterID HAVING count() > 100000 ORDER BY l DESC LIMIT 25;
+SELECT BrowserCountry, BrowserLanguage, count() AS c FROM hits GROUP BY BrowserCountry, BrowserLanguage ORDER BY c DESC LIMIT 10;
+SELECT Title, URL, count() AS c FROM hits GROUP BY Title, URL ORDER BY c DESC LIMIT 10;
+SELECT countIf(Not match(URL, '^https')) FROM hits;
+SELECT countIf(position(URL, 'google') > 0) FROM hits;
+SELECT CounterID, EventTime - lagInFrame(EventTime) OVER (PARTITION BY CounterID ORDER BY EventTime) AS dt FROM hits WHERE CounterID = 62 ORDER BY dt DESC LIMIT 10;
+SELECT min(URL), max(URL) FROM hits;
+SELECT URL, length(URL) AS l FROM hits ORDER BY l DESC LIMIT 10;
+SELECT substr(URL, 1, 8) AS p, count() AS c FROM hits GROUP BY p ORDER BY c DESC LIMIT 10;
+SELECT quantilesExact(0.1, 0.5, 0.9)(ResponseEndTiming) FROM hits WHERE ResponseEndTiming > 0;
+SELECT quantileExact(0.99)(ResponseEndTiming) FROM hits WHERE ResponseEndTiming > 0;
+SELECT toHour(toTimeZone(toDateTime(EventTime), 'UTC')) AS h, count() AS c FROM hits GROUP BY h ORDER BY h;
+SELECT EventTime, count() AS c FROM hits GROUP BY EventTime ORDER BY c DESC LIMIT 10;

--- a/duckdb-parquet/queries.sql
+++ b/duckdb-parquet/queries.sql
@@ -41,3 +41,18 @@ SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN (SearchEngineID = 
 SELECT URLHash, EventDate, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND TraficSourceID IN (-1, 6) AND RefererHash = 3594120000172545465 GROUP BY URLHash, EventDate ORDER BY PageViews DESC LIMIT 10 OFFSET 100;
 SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND DontCountHits = 0 AND URLHash = 2868770270353813622 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY PageViews DESC LIMIT 10 OFFSET 10000;
 SELECT DATE_TRUNC('minute', toDateTime(EventTime)) AS M, COUNT(*) AS PageViews FROM hits WHERE CounterID = 62 AND EventDate >= '2013-07-14' AND EventDate <= '2013-07-15' AND IsRefresh = 0 AND DontCountHits = 0 GROUP BY DATE_TRUNC('minute', toDateTime(EventTime)) ORDER BY DATE_TRUNC('minute', toDateTime(EventTime)) LIMIT 10 OFFSET 1000;
+SELECT UserID, RANK() OVER (ORDER BY EventTime) AS r FROM hits ORDER BY r DESC LIMIT 10;
+SELECT * FROM hits ORDER BY ClientIP, EventTime LIMIT 100;
+SELECT CounterID, avg(length(Referer)) AS l FROM hits WHERE Referer <> '' GROUP BY CounterID HAVING count(*) > 100000 ORDER BY l DESC LIMIT 25;
+SELECT BrowserCountry, BrowserLanguage, count(*) AS c FROM hits GROUP BY BrowserCountry, BrowserLanguage ORDER BY c DESC LIMIT 10;
+SELECT Title, URL, count(*) AS c FROM hits GROUP BY Title, URL ORDER BY c DESC LIMIT 10;
+SELECT count(*) FILTER (WHERE NOT REGEXP_MATCHES(URL, '^https')) FROM hits;
+SELECT count(*) FILTER (WHERE strpos(URL, 'google') > 0) FROM hits;
+SELECT CounterID, COALESCE(EventTime - lag(EventTime) OVER (PARTITION BY CounterID ORDER BY EventTime), EventTime) AS dt FROM hits WHERE CounterID = 62 ORDER BY dt DESC LIMIT 10;
+SELECT min(URL), max(URL) FROM hits;
+SELECT URL, length(URL) AS l FROM hits ORDER BY l DESC LIMIT 10;
+SELECT substr(URL, 1, 8) AS p, count(*) AS c FROM hits GROUP BY p ORDER BY c DESC LIMIT 10;
+SELECT percentile_cont(0.1) WITHIN GROUP (ORDER BY ResponseEndTiming), percentile_cont(0.5) WITHIN GROUP (ORDER BY ResponseEndTiming), percentile_cont(0.9) WITHIN GROUP (ORDER BY ResponseEndTiming) FROM hits WHERE ResponseEndTiming > 0;
+SELECT percentile_cont(0.99) WITHIN GROUP (ORDER BY ResponseEndTiming) FROM hits WHERE ResponseEndTiming > 0;
+SELECT hour(toDateTime(EventTime)) AS h, count(*) AS c FROM hits GROUP BY h ORDER BY h;
+SELECT EventTime, count(*) AS c FROM hits GROUP BY EventTime ORDER BY c DESC LIMIT 10;


### PR DESCRIPTION
Closes [#1488](https://github.com/ClickHouse/ClickBench/issues/1488)

Timings for the 15 added queries (Q44–58), best-of-3, seconds:

| Q | Query pattern | ClickHouse | DuckDB | ch/dd |
|---|--------------|-----------:|-------:|------:|
| 44 | `RANK() OVER (ORDER BY EventTime)` | 14.337 | 1.874 | 7.65 |
| 45 | `SELECT * ... ORDER BY ClientIP, EventTime LIMIT 100` | 18.893 | 2.939 | 6.43 |
| 46 | `AVG(length(Referer)) ... HAVING count()>100000` | 2.449 | 0.665 | 3.68 |
| 47 | `GROUP BY BrowserCountry, BrowserLanguage` | 0.773 | 0.223 | 3.47 |
| 48 | `GROUP BY Title, URL` | 10.577 | 3.511 | 3.01 |
| 49 | `countIf(NOT match(URL,'^https'))` | 1.570 | 0.664 | 2.36 |
| 50 | `countIf(position(URL,'google')>0)` | 1.573 | 0.728 | 2.16 |
| 51 | `lagInFrame(EventTime) OVER (PARTITION BY CounterID)` | 0.236 | 0.112 | 2.11 |
| 52 | `MIN(URL), MAX(URL)` | 1.630 | 0.683 | 2.39 |
| 53 | `ORDER BY length(URL) DESC LIMIT 10` | 1.435 | 0.779 | 1.84 |
| 54 | `GROUP BY substr(URL,1,8)` | 1.474 | 0.797 | 1.85 |
| 55 | `quantilesExact(0.1,0.5,0.9)(ResponseEndTiming)` | 0.365 | 1.299 | **0.28** |
| 56 | `quantileExact(0.99)(ResponseEndTiming)` | 0.285 | 0.463 | 0.62 |
| 57 | `GROUP BY toHour(toDateTime(EventTime))` | 0.221 | 0.323 | 0.68 |
| 58 | `GROUP BY EventTime ORDER BY count() DESC` | 0.443 | 0.645 | 0.69 |

Ratio >1 = DuckDB faster, <1 = ClickHouse faster.

Biggest discriminators: Q44 global window sort (7.7x DD), Q45 full-row multi-key sort (6.4x DD), Q48 two-string GROUP BY (3.0x DD), and Q55 multi-quantile (3.6x CH). Note Q44/45/48 cost 10–24s on ClickHouse, so they dominate total sweep time.

