### PR TITLE
Rebuild the website on a schedule

### DIFF
--- a/.github/workflows/generate-results.yml
+++ b/.github/workflows/generate-results.yml
@@ -1,12 +1,23 @@
 name: "Build the website"
 on:
   workflow_dispatch:  # This allows manual trigger from the UI
+  # Most pushes to main come from automation authenticated with GITHUB_TOKEN
+  # (the auto-merged `auto-results/*` PRs and the daily ClickHouse Cloud
+  # commit). GitHub does not emit workflow-triggering events for those, so the
+  # `push` trigger below only fires for human pushes. The schedule makes sure
+  # the site picks up automated results as well.
+  schedule:
+    - cron: '25 * * * *'
   push:
     branches:
       - main
 
 permissions:
   contents: write
+
+# The scheduled run and a push run must not race on `git push`.
+concurrency:
+  group: generate-results
 
 jobs:
   build:
@@ -28,5 +39,7 @@ jobs:
         if git status | grep -q modified
         then
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          # Results can land between the checkout and the push.
+          git pull --rebase
           git push
         fi


### PR DESCRIPTION
The website is generated by the "Build the website" workflow, which only ran on `push` to main. But almost every push to main comes from automation authenticated with `GITHUB_TOKEN` — the auto-merged `auto-results/*` PRs (`collect-new-results.py` merges them with `GH_TOKEN: ${{ github.token }}`) and the daily ClickHouse Cloud commit — and GitHub does not emit workflow-triggering events for those.

So the site was only ever rebuilt when a human merged something. The last such merge was #1490 on Aug 21 02:08 UTC; `data.generated.js` has been stuck with `2026-08-20` as its newest data point ever since, even though results for Aug 21–24 have all landed in the repo.

Changes:

- **`schedule: '25 * * * *'`** — hourly, offset off the hour so it does not collide with the `collect-results` cron (`7,37 * * * *`) or `clickhouse-cloud` (`10 10 * * *`). The job takes ~20s.
- **`concurrency: generate-results`** — a scheduled run and a push run would otherwise race on `git push`.
- **`git pull --rebase` before `git push`** — the collect bot pushes to main every 30 minutes, so a result can land between the checkout and the push and reject it as non-fast-forward. Latent before; on an hourly schedule it would hit regularly.

The existing `if: github.event.commits[0].message != env.CI_COMMIT_MESSAGE` guard still behaves correctly on `schedule`: `github.event.commits` is null, so the comparison is true and the job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)