### PR TITLE
versions: wait for background merges to settle before benchmarking

### DIFF
--- a/versions/README.md
+++ b/versions/README.md
@@ -61,7 +61,10 @@ in its own container — from `1.1.54xxx` (2018) to today — with no host insta
 4. **`run-version.sh <version> [image]`** — starts the server, creates each
    dataset's tables **in its own database** (so same-named tables like TPC-H and
    TPC-DS `customer` don't collide), loads each Native file with the simplest
-   possible `clickhouse-client INSERT … FORMAT Native`, then times every query in
+   possible `clickhouse-client INSERT … FORMAT Native`, waits for background
+   merges to settle (bounded by `MERGE_SETTLE_TIMEOUT`, default 1 h) so every
+   version is benchmarked against the settled table state rather than whatever
+   merge backlog its load left behind, then times every query in
    `queries/{mgbench,ssb,hits,tpch,tpcds,coffeeshop,taxi}.sql` (`TRIES` runs each,
    dropping the page cache between queries) and writes `results/<version>.json`.
 

--- a/versions/run-version.sh
+++ b/versions/run-version.sh
@@ -383,6 +383,44 @@ load_data() {
 
 drop_caches() { sync; echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null 2>&1; }
 
+# Wait until background merges settle before timing queries, so every version is
+# benchmarked against the same table state (the settled one) rather than against
+# whatever merge backlog its load left behind. Historically the single-threaded
+# INSERT was slow enough that merges finished within the load window; since
+# ClickHouse 26.8 a plain INSERT runs with max_insert_threads = all cores
+# (ClickHouse/ClickHouse#109000), the load saturates the machine and defers most
+# of the merge work past the INSERT -- right into the query phase, where it
+# competes with the queries for CPU, disk and page cache. That skewed the 26.9
+# master results: mgbench/ssb run first and absorbed the merge storm (ssb hot
+# runs degraded up to 130x), while hits and later datasets ran on a settled
+# server and showed master's genuine speedups.
+# Polls the server-wide system.merges; requires a few consecutive empty reads
+# (a lull between back-to-back merges must not end the wait), gives up after
+# MERGE_SETTLE_TIMEOUT seconds (default 1 h) and on versions where the count
+# cannot be read (prehistoric builds without system.merges, or Log tables that
+# never merge).
+wait_for_merges_to_settle() {
+    local timeout_s="${MERGE_SETTLE_TIMEOUT:-3600}" t0=${SECONDS} zeros=0 cnt last_log=0
+    while true; do
+        cnt=$(client --query "SELECT count() FROM system.merges" </dev/null 2>/dev/null | tr -d '[:space:]\r')
+        case "${cnt}" in
+            '') echo "merge settle: cannot read system.merges on ${VERSION}; not waiting" >&2; return 0 ;;
+            0)  zeros=$((zeros + 1)); [ "${zeros}" -ge 3 ] && break ;;
+            *)  zeros=0 ;;
+        esac
+        if [ $((SECONDS - t0)) -ge "${timeout_s}" ]; then
+            echo "merge settle: still ${cnt} merges running after ${timeout_s}s; benchmarking anyway" >&2
+            return 0
+        fi
+        if [ $((SECONDS - last_log)) -ge 60 ]; then
+            echo "merge settle: ${cnt:-?} merges running, $((SECONDS - t0))s elapsed" >&2
+            last_log=${SECONDS}
+        fi
+        sleep 10
+    done
+    echo "merge settle: background merges finished $((SECONDS - t0))s after load" >&2
+}
+
 # </dev/null: the client runs via `docker {exec,run} -i`, which would otherwise
 # read the caller's stdin — and the benchmark loop reads its query file on
 # stdin, so a bare probe here would swallow the remaining queries.
@@ -662,6 +700,8 @@ run_benchmark() {
     ACTUAL=$(server_version)
     RELEASE=$(release_date)
     echo "benchmarking ${VERSION} (server reports ${ACTUAL:-unknown}, released ${RELEASE:-unknown})" >&2
+    # Also stabilizes data_size below: it is measured on the settled parts, not mid-merge.
+    wait_for_merges_to_settle
     # Datasets that loaded in full. A dataset with even one table that failed to load is
     # not benchmarked (its queries record null) and reports neither load time nor size.
     for ds in ${QUERY_ORDER}; do


### PR DESCRIPTION
The 2026-08-26 master (26.9.1.170) run of the versions benchmark showed strange, massive degradations on `ssb` (hot runs up to 130x slower: Q1 0.064s → 8.4s, Q7 1.5s → 32s), visible at https://benchmark.clickhouse.com/versions/#version=-&dataset=+sb&metric=hot&queries=-

Investigation showed these are not per-query engine regressions but an artifact of *when* the queries run relative to deferred background merge work:

- Since ClickHouse 26.8, a plain `INSERT` runs with `max_insert_threads` = all cores (https://github.com/ClickHouse/ClickHouse/pull/109000). The bulk Native load saturates the machine, so background merges barely progress during the load window.
- The load finishes ~2x faster (`ssb` load: 737s vs 1569s on 26.7.1.1315 — 737s is exactly the 87 GB / 125 MB/s gp3 throughput floor), and the deferred merge work (~1.7x write amplification) lands in the query phase, competing with the queries for CPU, disk bandwidth and page cache on the c7a.4xlarge (16 vCPU, 32 GB).
- The master results show the exact churn timeline: `mgbench` (benchmarked first) is mildly elevated (hot +12-50%, colds up to 3x), `ssb` (second, the largest single-INSERT dataset) degrades catastrophically with tapering successive tries (Q7: 40/45/39/35/32s) and recovers from Q8 on, and `hits` (third) is consistently *faster* on master (0.6-0.9x) — the genuine engine improvements, visible once the merge storm has ended.
- Local A/B (26.9.1.187 vs 26.7.1.1315, same SF10 data, same DDL, settled tables) confirms no per-query regression: master is equal or faster on all 13 `ssb` queries, but accumulates ~3.6x more post-load merge wall time under an unconstrained load (`MergeTotalMilliseconds` 8417s vs 2321s for the same inserted data).

The fix: after loading, wait for the server-wide `system.merges` to drain (bounded by `MERGE_SETTLE_TIMEOUT`, default 1 h; requires a few consecutive empty reads; skips gracefully on prehistoric builds without `system.merges`) before starting the query phase. Every version is then measured against the same, settled table state — the state the old single-threaded loads reached implicitly within the load window. This also stabilizes the reported `data_size` (measured on settled parts, not mid-merge).

The wait mostly displaces time the merge storm would otherwise steal from the query phase, so the total run duration stays within the existing 5 h VM budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)