### PR TITLE
Tag the remaining systems that do not restart before a cold run

### DIFF
--- a/athena-partitioned/results/20220701/serverless.json
+++ b/athena-partitioned/results/20220701/serverless.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["stateless", "managed", "Java", "column-oriented", "aws"],
+    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "no-cold"],
 
     "load_time": 0,
     "data_size": 13800000000,

--- a/athena/results/20220701/serverless.json
+++ b/athena/results/20220701/serverless.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "historical"],
+    "tags": ["stateless", "managed", "Java", "column-oriented", "aws", "historical", "no-cold"],
 
     "load_time": 0,
     "data_size": 13800000000,

--- a/aurora-mysql/results/20220701/16acu.json
+++ b/aurora-mysql/results/20220701/16acu.json
@@ -12,7 +12,8 @@
         "C++",
         "MySQL compatible",
         "row-oriented",
-        "aws"
+        "aws",
+        "no-cold"
     ],
     "load_time": 7687,
     "data_size": 89614492631,

--- a/aurora-postgresql/results/20220701/16acu.json
+++ b/aurora-postgresql/results/20220701/16acu.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "C", "PostgreSQL compatible", "row-oriented", "aws"],
+    "tags": ["managed", "C", "PostgreSQL compatible", "row-oriented", "aws", "no-cold"],
 
     "load_time": 2127,
     "data_size": 52183852646,

--- a/bigquery/results/20250409/result.json
+++ b/bigquery/results/20250409/result.json
@@ -10,7 +10,8 @@
         "serverless",
         "column-oriented",
         "gcp",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 1146,
     "data_size": 8760000000,

--- a/bigquery/results/20251028/result.json
+++ b/bigquery/results/20251028/result.json
@@ -10,7 +10,8 @@
         "serverless",
         "column-oriented",
         "gcp",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 777,
     "data_size": 8760000000,

--- a/bytehouse/results/20220716/l.json
+++ b/bytehouse/results/20220716/l.json
@@ -10,7 +10,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220716/m.json
+++ b/bytehouse/results/20220716/m.json
@@ -10,7 +10,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220716/s.json
+++ b/bytehouse/results/20220716/s.json
@@ -10,7 +10,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220716/xs.json
+++ b/bytehouse/results/20220716/xs.json
@@ -10,7 +10,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/l.json
+++ b/bytehouse/results/20220727/l.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/m.json
+++ b/bytehouse/results/20220727/m.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/s.json
+++ b/bytehouse/results/20220727/s.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/bytehouse/results/20220727/xs.json
+++ b/bytehouse/results/20220727/xs.json
@@ -11,7 +11,8 @@
         "column-oriented",
         "ClickHouse derivative",
         "C++",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 745,
     "data_size": 27190000000,

--- a/chyt/results/20240916/yt.360GB_YC.json
+++ b/chyt/results/20240916/yt.360GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "no-cold"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.48GB_YC.json
+++ b/chyt/results/20240916/yt.48GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "no-cold"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.720GB_YC.json
+++ b/chyt/results/20240916/yt.720GB_YC.json
@@ -10,7 +10,8 @@
         "ClickHouse derivative",
         "managed",
         "YT",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 0,
     "data_size": 11991598975,

--- a/chyt/results/20240916/yt.96GB_YC.json
+++ b/chyt/results/20240916/yt.96GB_YC.json
@@ -9,7 +9,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "no-cold"],
 
     "load_time": 0,
     "data_size": 11991598975,

--- a/crunchy-bridge-for-analytics/results/20240605/crunchy-bridge-analytics-256.json
+++ b/crunchy-bridge-for-analytics/results/20240605/crunchy-bridge-analytics-256.json
@@ -7,7 +7,7 @@
     "hardware": "cpu",
     "tuned": "no",
     "comment":"",
-    "tags": ["column-oriented","DuckDB derivative", "PostgreSQL compatible", "managed"],
+    "tags": ["column-oriented","DuckDB derivative", "PostgreSQL compatible", "managed", "no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
 

--- a/firebolt-parquet-partitioned/results/20260221/c6a.2xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260221/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c6a.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260221/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c6a.large.json
+++ b/firebolt-parquet-partitioned/results/20260221/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c6a.metal.json
+++ b/firebolt-parquet-partitioned/results/20260221/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c6a.xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260221/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c7a.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260221/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c8g.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260221/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260221/c8g.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260221/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c6a.2xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260510/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c6a.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260510/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c6a.large.json
+++ b/firebolt-parquet-partitioned/results/20260510/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c6a.metal.json
+++ b/firebolt-parquet-partitioned/results/20260510/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c6a.xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260510/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c7a.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260510/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c8g.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260510/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260510/c8g.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260510/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "result": [

--- a/firebolt-parquet-partitioned/results/20260511/c6a.2xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260511/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c6a.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260511/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c6a.large.json
+++ b/firebolt-parquet-partitioned/results/20260511/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c6a.metal.json
+++ b/firebolt-parquet-partitioned/results/20260511/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c6a.xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260511/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c7a.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260511/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c8g.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260511/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260511/c8g.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260511/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14737666736,
     "concurrent_qps": null,

--- a/firebolt-parquet-partitioned/results/20260827/c6a.2xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260827/c6a.2xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 10,
       "data_size": 14737666736,
       "concurrent_qps": 0.12,

--- a/firebolt-parquet-partitioned/results/20260827/c6a.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260827/c6a.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 20,
       "data_size": 14737666736,
       "concurrent_qps": 0.397,

--- a/firebolt-parquet-partitioned/results/20260827/c6a.large.json
+++ b/firebolt-parquet-partitioned/results/20260827/c6a.large.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 1,
       "data_size": 14737666736,
       "concurrent_qps": 0.172,

--- a/firebolt-parquet-partitioned/results/20260827/c6a.metal.json
+++ b/firebolt-parquet-partitioned/results/20260827/c6a.metal.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 19,
       "data_size": 14737666736,
       "concurrent_qps": 3.298,

--- a/firebolt-parquet-partitioned/results/20260827/c6a.xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260827/c6a.xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 4,
       "data_size": 14737666736,
       "concurrent_qps": 0.128,

--- a/firebolt-parquet-partitioned/results/20260827/c7a.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260827/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 62,
       "data_size": 14737666736,
       "concurrent_qps": 6.187,

--- a/firebolt-parquet-partitioned/results/20260827/c8g.4xlarge.json
+++ b/firebolt-parquet-partitioned/results/20260827/c8g.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 21,
       "data_size": 14737666736,
       "concurrent_qps": 1.055,

--- a/firebolt-parquet-partitioned/results/20260827/c8g.metal-48xl.json
+++ b/firebolt-parquet-partitioned/results/20260827/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 62,
       "data_size": 14737666736,
       "concurrent_qps": 7.19,

--- a/firebolt-parquet-partitioned/results/20260827/t3a.small.json
+++ b/firebolt-parquet-partitioned/results/20260827/t3a.small.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 0,
       "data_size": 14737666736,
       "concurrent_qps": 0.045,

--- a/firebolt-parquet-partitioned/template.json
+++ b/firebolt-parquet-partitioned/template.json
@@ -8,6 +8,7 @@
     "column-oriented",
     "PostgreSQL compatible",
     "ClickHouse derivative",
-    "stateless"
+    "stateless",
+    "no-cold"
   ]
 }

--- a/firebolt-parquet/results/20260221/c6a.2xlarge.json
+++ b/firebolt-parquet/results/20260221/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c6a.4xlarge.json
+++ b/firebolt-parquet/results/20260221/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c6a.large.json
+++ b/firebolt-parquet/results/20260221/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c6a.metal.json
+++ b/firebolt-parquet/results/20260221/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c6a.xlarge.json
+++ b/firebolt-parquet/results/20260221/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c7a.metal-48xl.json
+++ b/firebolt-parquet/results/20260221/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c8g.4xlarge.json
+++ b/firebolt-parquet/results/20260221/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260221/c8g.metal-48xl.json
+++ b/firebolt-parquet/results/20260221/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c6a.2xlarge.json
+++ b/firebolt-parquet/results/20260510/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c6a.4xlarge.json
+++ b/firebolt-parquet/results/20260510/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c6a.large.json
+++ b/firebolt-parquet/results/20260510/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c6a.metal.json
+++ b/firebolt-parquet/results/20260510/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c6a.xlarge.json
+++ b/firebolt-parquet/results/20260510/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c7a.metal-48xl.json
+++ b/firebolt-parquet/results/20260510/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c8g.4xlarge.json
+++ b/firebolt-parquet/results/20260510/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260510/c8g.metal-48xl.json
+++ b/firebolt-parquet/results/20260510/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "result": [

--- a/firebolt-parquet/results/20260511/c6a.2xlarge.json
+++ b/firebolt-parquet/results/20260511/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c6a.4xlarge.json
+++ b/firebolt-parquet/results/20260511/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c6a.large.json
+++ b/firebolt-parquet/results/20260511/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c6a.metal.json
+++ b/firebolt-parquet/results/20260511/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c6a.xlarge.json
+++ b/firebolt-parquet/results/20260511/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c7a.metal-48xl.json
+++ b/firebolt-parquet/results/20260511/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c8g.4xlarge.json
+++ b/firebolt-parquet/results/20260511/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260511/c8g.metal-48xl.json
+++ b/firebolt-parquet/results/20260511/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
     "load_time": 0,
     "data_size": 14779976446,
     "concurrent_qps": null,

--- a/firebolt-parquet/results/20260827/c6a.2xlarge.json
+++ b/firebolt-parquet/results/20260827/c6a.2xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 5,
       "data_size": 14779976446,
       "concurrent_qps": 0.2,

--- a/firebolt-parquet/results/20260827/c6a.4xlarge.json
+++ b/firebolt-parquet/results/20260827/c6a.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 2,
       "data_size": 14779976446,
       "concurrent_qps": 0.817,

--- a/firebolt-parquet/results/20260827/c6a.large.json
+++ b/firebolt-parquet/results/20260827/c6a.large.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 0,
       "data_size": 14779976446,
       "concurrent_qps": 0.048,

--- a/firebolt-parquet/results/20260827/c6a.metal.json
+++ b/firebolt-parquet/results/20260827/c6a.metal.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 0,
       "data_size": 14779976446,
       "concurrent_qps": 4.352,

--- a/firebolt-parquet/results/20260827/c6a.xlarge.json
+++ b/firebolt-parquet/results/20260827/c6a.xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 1,
       "data_size": 14779976446,
       "concurrent_qps": 0.195,

--- a/firebolt-parquet/results/20260827/c7a.metal-48xl.json
+++ b/firebolt-parquet/results/20260827/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 4,
       "data_size": 14779976446,
       "concurrent_qps": 6.822,

--- a/firebolt-parquet/results/20260827/c8g.4xlarge.json
+++ b/firebolt-parquet/results/20260827/c8g.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 2,
       "data_size": 14779976446,
       "concurrent_qps": 1.127,

--- a/firebolt-parquet/results/20260827/c8g.metal-48xl.json
+++ b/firebolt-parquet/results/20260827/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 5,
       "data_size": 14779976446,
       "concurrent_qps": 7.977,

--- a/firebolt-parquet/results/20260827/t3a.small.json
+++ b/firebolt-parquet/results/20260827/t3a.small.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","stateless","no-cold"],
       "load_time": 0,
       "data_size": 14779976446,
       "concurrent_qps": 0.075,

--- a/firebolt-parquet/template.json
+++ b/firebolt-parquet/template.json
@@ -8,6 +8,7 @@
     "column-oriented",
     "PostgreSQL compatible",
     "ClickHouse derivative",
-    "stateless"
+    "stateless",
+    "no-cold"
   ]
 }

--- a/firebolt/results/20250607/medium.json
+++ b/firebolt/results/20250607/medium.json
@@ -8,7 +8,8 @@
         "C++",
         "column-oriented",
         "ClickHouse derivative",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 0,
     "data_size": 14730000000,

--- a/firebolt/results/20250607/small.json
+++ b/firebolt/results/20250607/small.json
@@ -8,7 +8,8 @@
         "C++",
         "column-oriented",
         "ClickHouse derivative",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 0,
     "data_size": 14730000000,

--- a/firebolt/results/20260510/c6a.2xlarge.json
+++ b/firebolt/results/20260510/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 263,
     "data_size": 15786335659,
     "result": [

--- a/firebolt/results/20260510/c6a.4xlarge.json
+++ b/firebolt/results/20260510/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 266,
     "data_size": 15784894582,
     "result": [

--- a/firebolt/results/20260510/c6a.large.json
+++ b/firebolt/results/20260510/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 473,
     "data_size": 15783572100,
     "result": [

--- a/firebolt/results/20260510/c6a.metal.json
+++ b/firebolt/results/20260510/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 129,
     "data_size": 15790604135,
     "result": [

--- a/firebolt/results/20260510/c6a.xlarge.json
+++ b/firebolt/results/20260510/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 334,
     "data_size": 15786046105,
     "result": [

--- a/firebolt/results/20260510/c7a.metal-48xl.json
+++ b/firebolt/results/20260510/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 175,
     "data_size": 15789712946,
     "result": [

--- a/firebolt/results/20260510/c8g.4xlarge.json
+++ b/firebolt/results/20260510/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 267,
     "data_size": 15790454293,
     "result": [

--- a/firebolt/results/20260510/c8g.metal-48xl.json
+++ b/firebolt/results/20260510/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 130,
     "data_size": 15792690215,
     "result": [

--- a/firebolt/results/20260511/c6a.2xlarge.json
+++ b/firebolt/results/20260511/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 281,
     "data_size": 15786247920,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c6a.4xlarge.json
+++ b/firebolt/results/20260511/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 234,
     "data_size": 15784594679,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c6a.large.json
+++ b/firebolt/results/20260511/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 497,
     "data_size": 15783568373,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c6a.metal.json
+++ b/firebolt/results/20260511/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 129,
     "data_size": 15790873826,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c6a.xlarge.json
+++ b/firebolt/results/20260511/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 348,
     "data_size": 15786025122,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c7a.metal-48xl.json
+++ b/firebolt/results/20260511/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 90,
     "data_size": 15793756500,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c8g.4xlarge.json
+++ b/firebolt/results/20260511/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 257,
     "data_size": 15791052210,
     "concurrent_qps": null,

--- a/firebolt/results/20260511/c8g.metal-48xl.json
+++ b/firebolt/results/20260511/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 75,
     "data_size": 15794858823,
     "concurrent_qps": null,

--- a/firebolt/results/20260517/c6a.2xlarge.json
+++ b/firebolt/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 285,
     "data_size": 15827354954,
     "concurrent_qps": 0.375,

--- a/firebolt/results/20260517/c6a.4xlarge.json
+++ b/firebolt/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 235,
     "data_size": 15825985134,
     "concurrent_qps": 1.908,

--- a/firebolt/results/20260517/c6a.large.json
+++ b/firebolt/results/20260517/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 488,
     "data_size": 15816235785,
     "concurrent_qps": 0.262,

--- a/firebolt/results/20260517/c6a.metal.json
+++ b/firebolt/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 172,
     "data_size": 15823268468,
     "concurrent_qps": 9.84,

--- a/firebolt/results/20260517/c6a.xlarge.json
+++ b/firebolt/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 330,
     "data_size": 15827881790,
     "concurrent_qps": 0.2,

--- a/firebolt/results/20260517/c7a.metal-48xl.json
+++ b/firebolt/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 197,
     "data_size": 15826419844,
     "concurrent_qps": 18.902,

--- a/firebolt/results/20260517/c8g.4xlarge.json
+++ b/firebolt/results/20260517/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 241,
     "data_size": 15827812385,
     "concurrent_qps": 3.773,

--- a/firebolt/results/20260517/c8g.metal-48xl.json
+++ b/firebolt/results/20260517/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 175,
     "data_size": 15825383440,
     "concurrent_qps": 19.565,

--- a/firebolt/results/20260701/c6a.2xlarge.json
+++ b/firebolt/results/20260701/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 268,
     "data_size": 15827763113,
     "result": [

--- a/firebolt/results/20260701/c6a.4xlarge.json
+++ b/firebolt/results/20260701/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 250,
     "data_size": 15817570420,
     "result": [

--- a/firebolt/results/20260701/c6a.large.json
+++ b/firebolt/results/20260701/c6a.large.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 482,
     "data_size": 15816031161,
     "result": [

--- a/firebolt/results/20260701/c6a.metal.json
+++ b/firebolt/results/20260701/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 174,
     "data_size": 15823508662,
     "result": [

--- a/firebolt/results/20260701/c6a.xlarge.json
+++ b/firebolt/results/20260701/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 387,
     "data_size": 15826959511,
     "result": [

--- a/firebolt/results/20260701/c7a.metal-48xl.json
+++ b/firebolt/results/20260701/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 217,
     "data_size": 15824970290,
     "result": [

--- a/firebolt/results/20260701/c8g.4xlarge.json
+++ b/firebolt/results/20260701/c8g.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 271,
     "data_size": 15823115670,
     "result": [

--- a/firebolt/results/20260701/c8g.metal-48xl.json
+++ b/firebolt/results/20260701/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "yes",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+    "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
     "load_time": 165,
     "data_size": 15824820283,
     "result": [

--- a/firebolt/results/20260825/c6a.2xlarge.json
+++ b/firebolt/results/20260825/c6a.2xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 244,
       "data_size": 15819132866,
       "concurrent_qps": 0.312,

--- a/firebolt/results/20260825/c6a.4xlarge.json
+++ b/firebolt/results/20260825/c6a.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 164,
       "data_size": 15819240783,
       "concurrent_qps": 0.425,

--- a/firebolt/results/20260825/c6a.large.json
+++ b/firebolt/results/20260825/c6a.large.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 521,
       "data_size": 15817503935,
       "concurrent_qps": 0.5,

--- a/firebolt/results/20260825/c6a.metal.json
+++ b/firebolt/results/20260825/c6a.metal.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 93,
       "data_size": 15830422307,
       "concurrent_qps": 24.113,

--- a/firebolt/results/20260825/c6a.xlarge.json
+++ b/firebolt/results/20260825/c6a.xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 326,
       "data_size": 15817749108,
       "concurrent_qps": 0.513,

--- a/firebolt/results/20260825/c7a.metal-48xl.json
+++ b/firebolt/results/20260825/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 79,
       "data_size": 15830435754,
       "concurrent_qps": 33.905,

--- a/firebolt/results/20260825/c8g.4xlarge.json
+++ b/firebolt/results/20260825/c8g.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 202,
       "data_size": 15825226034,
       "concurrent_qps": 0.495,

--- a/firebolt/results/20260825/c8g.metal-48xl.json
+++ b/firebolt/results/20260825/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 80,
       "data_size": 15830468937,
       "concurrent_qps": 42.42,

--- a/firebolt/results/20260827/c6a.2xlarge.json
+++ b/firebolt/results/20260827/c6a.2xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 238,
       "data_size": 15819127890,
       "concurrent_qps": 0.285,

--- a/firebolt/results/20260827/c6a.4xlarge.json
+++ b/firebolt/results/20260827/c6a.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 178,
       "data_size": 15819447968,
       "concurrent_qps": 0.418,

--- a/firebolt/results/20260827/c6a.large.json
+++ b/firebolt/results/20260827/c6a.large.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 507,
       "data_size": 15817294255,
       "concurrent_qps": 0.473,

--- a/firebolt/results/20260827/c6a.metal.json
+++ b/firebolt/results/20260827/c6a.metal.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 81,
       "data_size": 15830389860,
       "concurrent_qps": 24.155,

--- a/firebolt/results/20260827/c6a.xlarge.json
+++ b/firebolt/results/20260827/c6a.xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 367,
       "data_size": 15818968646,
       "concurrent_qps": 0.425,

--- a/firebolt/results/20260827/c7a.metal-48xl.json
+++ b/firebolt/results/20260827/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 80,
       "data_size": 15830952199,
       "concurrent_qps": 33.473,

--- a/firebolt/results/20260827/c8g.4xlarge.json
+++ b/firebolt/results/20260827/c8g.4xlarge.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 255,
       "data_size": 15825615373,
       "concurrent_qps": 0.413,

--- a/firebolt/results/20260827/c8g.metal-48xl.json
+++ b/firebolt/results/20260827/c8g.metal-48xl.json
@@ -6,7 +6,7 @@
       "proprietary": "yes",
       "hardware": "cpu",
       "tuned": "no",
-      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative"],
+      "tags": ["C++","column-oriented","PostgreSQL compatible","ClickHouse derivative","no-cold"],
       "load_time": 82,
       "data_size": 15830750443,
       "concurrent_qps": 42.297,

--- a/firebolt/template.json
+++ b/firebolt/template.json
@@ -7,6 +7,7 @@
     "C++",
     "column-oriented",
     "PostgreSQL compatible",
-    "ClickHouse derivative"
+    "ClickHouse derivative",
+    "no-cold"
   ]
 }

--- a/hydra/results/20221209/c6a.4xlarge.json
+++ b/hydra/results/20221209/c6a.4xlarge.json
@@ -6,7 +6,8 @@
     "comment": "",
     "tags": [
         "PostgreSQL compatible",
-        "column-oriented"
+        "column-oriented",
+        "no-cold"
     ],
     "load_time": 1320,
     "data_size": 18979994590,

--- a/hydra/results/20230919/c6a.4xlarge.json
+++ b/hydra/results/20230919/c6a.4xlarge.json
@@ -6,7 +6,8 @@
     "comment": "",
     "tags": [
         "PostgreSQL compatible",
-        "column-oriented"
+        "column-oriented",
+        "no-cold"
     ],
     "load_time": 1222,
     "data_size": 18995669982,

--- a/impala/results/20260517/c6a.2xlarge.json
+++ b/impala/results/20260517/c6a.2xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless","no-cold"],
     "load_time": 63,
     "data_size": 14779976446,
     "concurrent_qps": 0.23,

--- a/impala/results/20260517/c6a.4xlarge.json
+++ b/impala/results/20260517/c6a.4xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless","no-cold"],
     "load_time": 55,
     "data_size": 14779976446,
     "concurrent_qps": 0.498,

--- a/impala/results/20260517/c6a.metal.json
+++ b/impala/results/20260517/c6a.metal.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless","no-cold"],
     "load_time": 51,
     "data_size": 14779976446,
     "concurrent_qps": 0.933,

--- a/impala/results/20260517/c6a.xlarge.json
+++ b/impala/results/20260517/c6a.xlarge.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless","no-cold"],
     "load_time": 94,
     "data_size": 14779976446,
     "concurrent_qps": 0.113,

--- a/impala/results/20260517/c7a.metal-48xl.json
+++ b/impala/results/20260517/c7a.metal-48xl.json
@@ -6,7 +6,7 @@
     "proprietary": "no",
     "hardware": "cpu",
     "tuned": "no",
-    "tags": ["C++","MPP","column-oriented","stateless"],
+    "tags": ["C++","MPP","column-oriented","stateless","no-cold"],
     "load_time": 46,
     "data_size": 14779976446,
     "concurrent_qps": 0.988,

--- a/impala/template.json
+++ b/impala/template.json
@@ -7,6 +7,7 @@
     "C++",
     "MPP",
     "column-oriented",
-    "stateless"
+    "stateless",
+    "no-cold"
   ]
 }

--- a/redshift-serverless/results/20220701/serverless.json
+++ b/redshift-serverless/results/20220701/serverless.json
@@ -10,7 +10,8 @@
     "tags": [
         "managed",
         "column-oriented",
-        "aws"
+        "aws",
+        "no-cold"
     ],
     "load_time": 1933,
     "data_size": 30300000000,

--- a/redshift-serverless/results/20220729/serverless.json
+++ b/redshift-serverless/results/20220729/serverless.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "no-cold"],
 
   "load_time": 1889,
   "data_size": 30300000000,

--- a/redshift/results/20220701/4x.ra3.xplus.json
+++ b/redshift/results/20220701/4x.ra3.xplus.json
@@ -10,7 +10,8 @@
     "tags": [
         "managed",
         "column-oriented",
-        "aws"
+        "aws",
+        "no-cold"
     ],
     "load_time": 2136,
     "data_size": 30794579968,

--- a/redshift/results/20220714/4x.ra3.4xlarge.json
+++ b/redshift/results/20220714/4x.ra3.4xlarge.json
@@ -10,7 +10,8 @@
     "tags": [
         "managed",
         "column-oriented",
-        "aws"
+        "aws",
+        "no-cold"
     ],
     "load_time": 1906,
     "data_size": 22276997120,

--- a/redshift/results/20220725/4x.ra3.16xlarge.json
+++ b/redshift/results/20220725/4x.ra3.16xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "no-cold"],
 
   "load_time": 1829,
   "data_size": 26330791936,

--- a/redshift/results/20220725/4x.ra3.4xlarge.json
+++ b/redshift/results/20220725/4x.ra3.4xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "no-cold"],
 
   "load_time": 1904,
   "data_size": 22313697280,

--- a/redshift/results/20220729/4x.ra3.xplus.json
+++ b/redshift/results/20220729/4x.ra3.xplus.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "no-cold"],
 
   "load_time": 2103,
   "data_size": 21060648960,

--- a/redshift/results/20230316/2x.dc2.8xlarge.json
+++ b/redshift/results/20230316/2x.dc2.8xlarge.json
@@ -8,7 +8,7 @@
   "tuned": "no",
   "comment": "",
 
-  "tags": ["managed", "column-oriented", "aws"],
+  "tags": ["managed", "column-oriented", "aws", "no-cold"],
 
   "load_time": 2485,
   "data_size": 27278704640,

--- a/singlestore/results/20150405/historical-10m.json
+++ b/singlestore/results/20150405/historical-10m.json
@@ -10,7 +10,8 @@
     "tags": [
         "column-oriented",
         "MySQL compatible",
-        "historical"
+        "historical",
+        "no-cold"
     ],
     "load_time": 0,
     "data_size": 0,

--- a/singlestore/results/20220701/c6a.4xlarge.json
+++ b/singlestore/results/20220701/c6a.4xlarge.json
@@ -8,7 +8,7 @@
     "tuned": "yes",
     "comment": "Previous name: MemSQL. Some queries did not run due to memory limits",
 
-    "tags": ["MySQL compatible", "column-oriented"],
+    "tags": ["MySQL compatible", "column-oriented", "no-cold"],
 
     "load_time": 690,
     "data_size": 29836263469,

--- a/singlestore/results/20220715/s2.json
+++ b/singlestore/results/20220715/s2.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "Previous name: MemSQL. Some queries did not run due to unsupported regex",
 
-    "tags": ["MySQL compatible", "column-oriented", "managed"],
+    "tags": ["MySQL compatible", "column-oriented", "managed", "no-cold"],
 
     "load_time": 1145,
     "data_size": 19219978649,

--- a/singlestore/results/20220715/s24.json
+++ b/singlestore/results/20220715/s24.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "Previous name: MemSQL. Some queries did not run due to unsupported regex",
 
-    "tags": ["MySQL compatible", "column-oriented", "managed"],
+    "tags": ["MySQL compatible", "column-oriented", "managed", "no-cold"],
 
     "load_time": 1043,
     "data_size": 19219978649,

--- a/snowflake/results/20220701/2xl.json
+++ b/snowflake/results/20220701/2xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/3xl.json
+++ b/snowflake/results/20220701/3xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/4xl.json
+++ b/snowflake/results/20220701/4xl.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/l.json
+++ b/snowflake/results/20220701/l.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/m.json
+++ b/snowflake/results/20220701/m.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/s.json
+++ b/snowflake/results/20220701/s.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/xl.json
+++ b/snowflake/results/20220701/xl.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20220701/xs.json
+++ b/snowflake/results/20220701/xs.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 2524,
     "data_size": 12300000000,

--- a/snowflake/results/20260213/xs_interactive.json
+++ b/snowflake/results/20260213/xs_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/2xl_gen1.json
+++ b/snowflake/results/20260727/2xl_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/2xl_gen2.json
+++ b/snowflake/results/20260727/2xl_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/2xl_interactive.json
+++ b/snowflake/results/20260727/2xl_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/l_gen1.json
+++ b/snowflake/results/20260727/l_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/l_gen2.json
+++ b/snowflake/results/20260727/l_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/l_interactive.json
+++ b/snowflake/results/20260727/l_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/m_gen1.json
+++ b/snowflake/results/20260727/m_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/m_gen2.json
+++ b/snowflake/results/20260727/m_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/m_interactive.json
+++ b/snowflake/results/20260727/m_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/s_gen1.json
+++ b/snowflake/results/20260727/s_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/s_gen2.json
+++ b/snowflake/results/20260727/s_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/s_interactive.json
+++ b/snowflake/results/20260727/s_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xl_gen1.json
+++ b/snowflake/results/20260727/xl_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xl_gen2.json
+++ b/snowflake/results/20260727/xl_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xl_interactive.json
+++ b/snowflake/results/20260727/xl_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xs_gen1.json
+++ b/snowflake/results/20260727/xs_gen1.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xs_gen2.json
+++ b/snowflake/results/20260727/xs_gen2.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/snowflake/results/20260727/xs_interactive.json
+++ b/snowflake/results/20260727/xs_interactive.json
@@ -8,7 +8,7 @@
     "hardware": "cpu",
     "tuned": "no",
 
-    "tags": ["managed", "column-oriented"],
+    "tags": ["managed", "column-oriented", "no-cold"],
 
     "load_time": 67,
     "data_size": 13030859264,

--- a/timescale-cloud/results/20241115/16cpu.json
+++ b/timescale-cloud/results/20241115/16cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20241115/4cpu.json
+++ b/timescale-cloud/results/20241115/4cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20241115/8cpu.json
+++ b/timescale-cloud/results/20241115/8cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250626/16cpu.json
+++ b/timescale-cloud/results/20250626/16cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250626/4cpu.json
+++ b/timescale-cloud/results/20250626/4cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250626/8cpu.json
+++ b/timescale-cloud/results/20250626/8cpu.json
@@ -10,7 +10,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250703/16cpu.json
+++ b/timescale-cloud/results/20250703/16cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250703/4cpu.json
+++ b/timescale-cloud/results/20250703/4cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250703/8cpu.json
+++ b/timescale-cloud/results/20250703/8cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250704/16cpu.json
+++ b/timescale-cloud/results/20250704/16cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250704/4cpu.json
+++ b/timescale-cloud/results/20250704/4cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250704/8cpu.json
+++ b/timescale-cloud/results/20250704/8cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250707/16cpu.json
+++ b/timescale-cloud/results/20250707/16cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250707/4cpu.json
+++ b/timescale-cloud/results/20250707/4cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250707/8cpu.json
+++ b/timescale-cloud/results/20250707/8cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250713/16cpu.json
+++ b/timescale-cloud/results/20250713/16cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250713/4cpu.json
+++ b/timescale-cloud/results/20250713/4cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250713/8cpu.json
+++ b/timescale-cloud/results/20250713/8cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250909/16cpu.json
+++ b/timescale-cloud/results/20250909/16cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 3582,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250909/4cpu.json
+++ b/timescale-cloud/results/20250909/4cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4536,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20250909/8cpu.json
+++ b/timescale-cloud/results/20250909/8cpu.json
@@ -11,7 +11,8 @@
         "PostgreSQL compatible",
         "column-oriented",
         "time-series",
-        "managed"
+        "managed",
+        "no-cold"
     ],
     "load_time": 4100,
     "data_size": 19304824832,

--- a/timescale-cloud/results/20251210/16cpu.json
+++ b/timescale-cloud/results/20251210/16cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-10",
   "machine": "64GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
   "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251210/4cpu.json
+++ b/timescale-cloud/results/20251210/4cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-10",
   "machine": "16GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
   "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251210/8cpu.json
+++ b/timescale-cloud/results/20251210/8cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-10",
   "machine": "32GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
   "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251213/16cpu.json
+++ b/timescale-cloud/results/20251213/16cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "64GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251213/4cpu.json
+++ b/timescale-cloud/results/20251213/4cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "16GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/timescale-cloud/results/20251213/8cpu.json
+++ b/timescale-cloud/results/20251213/8cpu.json
@@ -3,7 +3,7 @@
   "date": "2025-12-13",
   "machine": "32GiB",
   "cluster_size": 1,
-  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed"],
+  "tags": ["C", "PostgreSQL compatible", "column-oriented", "time-series", "managed", "no-cold"],
   "proprietary": "yes",
     "hardware": "cpu",
   "tuned": "no",

--- a/tinybird/results/20241111/tinybird.json
+++ b/tinybird/results/20241111/tinybird.json
@@ -8,7 +8,7 @@
     "tuned": "no",
     "comment": "",
 
-    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed"],
+    "tags": ["C++", "column-oriented", "ClickHouse derivative", "managed", "no-cold"],
 
     "load_time": 0,
     "data_size": null,


### PR DESCRIPTION
df3529130 brought the classification up to date but only added the tag to the five managed services it looked at (ClickHouse Cloud, AlloyDB, Hologres, Databricks, MotherDuck). The same argument applies to every other entry whose first try of each query hits a live engine, and those were left untagged. README section 2.b makes the tag mandatory for submissions that do not restart the database, so add it to them.

Remote services driven by a hand-written run.sh that neither restarts anything server-side nor clears any cache. Tag every result file:

  - athena (1), athena-partitioned (1): start-query-execution only.
  - aurora-mysql (1), aurora-postgresql (1): plain psql/mysql loops.
  - bigquery (2): --use_cache=false disables the result cache, which section 2.b does not accept as a substitute for a restart.
  - bytehouse (8): bytehouse-cli against a remote warehouse.
  - chyt (4, one was already tagged): BENCH_RESTARTABLE=no, and ./stop is `exit 0` because the YT cluster is remote.
  - crunchy-bridge-for-analytics (1): turns the cache manager off for the first pass, but the server keeps running - the same situation as Hologres' freecache call, which df3529130 tagged.
  - hydra (2, the serverless run was already tagged): benchmark.sh loads and then calls run.sh, with no restart and no drop_caches anywhere in between.
  - redshift (6), redshift-serverless (2): only enable_result_cache_for_session = off.
  - singlestore (4): template.json already carried the tag as the one system df3529130 kept it on, but its result files never did.
  - snowflake (27), timescale-cloud (27), tinybird (1).

Local daemons that the shared driver deliberately does not restart. lib/benchmark-common.sh only runs the ./stop -> drop_caches -> ./start -> ./check cycle when BENCH_RESTARTABLE=yes; these four set it to no and fall through to bench_flush_caches alone, so the page cache is dropped while the engine keeps its internal caches. Each has a reason recorded in its own benchmark.sh: restarting catalogd would empty Impala's in-memory catalog, and firebolt-core keeps the loaded database in its bind-mounted volume. Tag the result files and template.json so future runs stay flagged:

  - impala (5 + template.json)
  - firebolt (50 + template.json; the 13 managed-cloud runs from 2025-06-23 onwards were already tagged, the two historical 2025-06-07 entries were not)
  - firebolt-parquet (33 + template.json)
  - firebolt-parquet-partitioned (33 + template.json)

The other systems that set BENCH_RESTARTABLE=no are genuine embedded CLIs whose ./start is `exit 0`, so they satisfy section 2.a implicitly and are left alone. That includes zighouse, which does have a server but whose ./query invokes the binary directly instead.
