### PR TITLE
Keep the dataset download out of the measured load window

### DIFF
--- a/lib/benchmark-common.sh
+++ b/lib/benchmark-common.sh
@@ -140,6 +140,12 @@ bench_flush_caches() {
 
 bench_install() {
     ./install
+    # Flush the installation's writeback here, where nothing is measured.
+    # Unpacking packages, Docker images and binaries leaves dirty pages
+    # behind, and whoever calls sync next pays for writing them out — which
+    # used to be the sync at the end of bench_load, charging an install to
+    # Load time. See the comment in bench_download.
+    sync
 }
 
 bench_start() {
@@ -164,6 +170,17 @@ bench_download() {
         return 0
     fi
     "$LIB_DIR/$BENCH_DOWNLOAD_SCRIPT"
+    # Same reasoning as in bench_install, and the effect is much larger here.
+    # Fetching and decompressing the dataset leaves tens of GB of dirty pages
+    # behind; the next sync writes them out. Until now that next sync was the
+    # one at the end of bench_load, so every system paid for its download's
+    # writeback inside its measured load window — and paid unevenly, because
+    # the volume depends on the input format the system happens to ingest
+    # (~70 GB of uncompressed TSV/CSV against ~14 GB of Parquet) rather than
+    # on anything the system did. The leftover dirty pages also made the
+    # first ./drop_caches cycle slower for the TSV/CSV systems. Syncing here,
+    # outside every measured window, keeps Load time about the load.
+    sync
 }
 
 bench_load() {


### PR DESCRIPTION
Reimplements the intent of #842 (now closed) for the shared driver.

## What #842 was about

Every system used to call `sync && echo 3 > /proc/sys/vm/drop_caches` in its own `run.sh` before the cold run. That `sync` also flushed the dirty pages of the *downloaded source* dataset (`hits.tsv`, `hits.csv`, `hits.parquet`, ...), which the system no longer needed after loading. The cost depended on which input format the system happened to ingest — ~70 GB of uncompressed TSV/CSV against ~14 GB of Parquet — so it leaked unevenly into cold-run preparation. #842 fixed that by adding a per-system `rm -f hits.*` to 33 `benchmark.sh` files.

## Why it needed reimplementing

Since then the per-system `benchmark.sh` files were replaced by the shared driver in `lib/benchmark-common.sh`, so all 33 hunks are gone, and the cache flush moved into `bench_flush_caches`, which runs *outside* the per-query timing. Deleting the source files no longer changes any query measurement.

What survives of the problem is one step earlier. `bench_load` ends with an unconditional `sync` inside its timed window (cc2655d48), so it is the first sync after the download and it writes back whatever the download and decompression left dirty. Every system therefore charged its download's writeback to `Load time`, in proportion to the size of its input format rather than to anything it did — the same unfairness #842 described, relocated from the cold run to the load time.

## The fix

`sync` at the end of `bench_download`, where nothing is measured, so `bench_load`'s sync only covers the load's own writes. `bench_install` gets the same treatment for the same reason — package and image unpacking was otherwise charged to `Load time` too.

Deleting the source files is not carried over: with the flush outside the query timing it buys no measurement fairness, and it would need per-system knowledge of who queries the downloaded file directly (`clickhouse-parquet`, `duckdb-parquet`, `datafusion`, `sail`, the `*-datalake` entries, ...) versus who ingests it. Freeing that disk space can be done separately if it turns out to be wanted.

## Test plan

- [ ] Run one ingest-from-TSV system (e.g. `mysql`, `starrocks`) and confirm `Load time` drops by the download's writeback and the run completes.
- [ ] Run one ingest-from-Parquet system (e.g. `clickhouse`, `duckdb`) and confirm the run completes; `Load time` should move much less.
- [ ] Run one direct-query system (e.g. `clickhouse-parquet`) to confirm nothing about the source files changed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)