### PR TITLE
Fix the missing first bar in the summary chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,8 +964,11 @@ function renderSummary(filtered_data) {
         [...Array(3).keys()].map(run_num =>
             Math.min(...filtered_data.filter(elem => !elem.fake).map(elem => elem.result[query_num]?.[run_num]).filter(x => x != null))));
 
-    const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x && x > 5));
-    const min_data_size = Math.min(...filtered_data.map(elem => elem.data_size).filter(x => x && x > 1e9));
+    /// The thresholds have to match the conditions below, where these minimums are used as the baselines:
+    /// otherwise a system sitting exactly on the boundary is compared against a baseline of Infinity,
+    /// which makes its ratio zero, and the bar collapses to nothing.
+    const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x >= 5));
+    const min_data_size = Math.min(...filtered_data.map(elem => elem.data_size).filter(x => x >= 1e9));
 
     let summaries;
     if (selectors.metric == 'load') {


### PR DESCRIPTION
The first bar does not render in [this view](https://benchmark.clickhouse.com/#system=+erDt|curp|Hoaus&type=-&machine=-6t|ca2|6ax|g4e|6ale|3al&cluster_size=-&opensource=-&hardware=+c&tuned=+n&metric=combined&queries=-) (CedarDB (Parquet) + ClickHouse (Parquet), combined metric).

### Cause

The baseline for the load time and data size components of the combined metric was computed over entries passing a strictly-greater threshold, while the components themselves are applied to entries passing a greater-or-equal one:

```js
const min_load_time = Math.min(...filtered_data.map(elem => elem.load_time).filter(x => x && x > 5));
...
combined_load_time_share * Math.log(elem.load_time >= 5 ? (elem.load_time / min_load_time) : 1)
```

In that selection every load time is 0, 1, 3 or 5 — nothing is `> 5`, so `Math.min` of an empty list returns `Infinity`. CedarDB (Parquet) on `c6a.4xlarge` loads in exactly 5s, which *does* satisfy `>= 5`, so its load time factor became `5 / Infinity == 0`, `Math.log(0) == -Infinity`, and the whole combined score collapsed to `exp(-Infinity) == 0`. A ratio of 0 sorts first and renders a bar of zero width.

### Fix

Make the thresholds match the conditions that consume them. The load time row of the detailed table already used `>= 5` for the same purpose, which confirms the intended boundary.

With the fix, CedarDB (Parquet) on `c6a.4xlarge` scores ×2.44 and sorts last, consistent with its cold and hot ratios of 2.24 and 3.37.

### Effect on the default view

`min_load_time` goes from 6 to 5, so entries with a counted load time shift by a uniform (6/5)^0.1 ≈ 1.8%. That swaps a handful of adjacent near-ties but changes nothing structural, and it is the correct baseline — a 5s load was always eligible to be counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)